### PR TITLE
feat: add up/down commands

### DIFF
--- a/cmd/cardano-up/down.go
+++ b/cmd/cardano-up/down.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/blinklabs-io/cardano-up/pkgmgr"
+	"github.com/spf13/cobra"
+)
+
+func downCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "down",
+		Short: "Stops all Docker containers",
+		Long:  `Stops all running Docker containers for installed packages in the current context.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pm, err := pkgmgr.NewDefaultPackageManager()
+			if err != nil {
+				slog.Error(fmt.Sprintf("failed to create package manager: %s", err))
+				os.Exit(1)
+			}
+			if err := pm.Down(); err != nil {
+				slog.Error(err.Error())
+				os.Exit(1)
+			}
+			return nil
+		},
+	}
+	return cmd
+}

--- a/cmd/cardano-up/main.go
+++ b/cmd/cardano-up/main.go
@@ -69,6 +69,8 @@ func main() {
 		listAvailableCommand(),
 		installCommand(),
 		uninstallCommand(),
+		upCommand(),
+		downCommand(),
 	)
 
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/cardano-up/up.go
+++ b/cmd/cardano-up/up.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/blinklabs-io/cardano-up/pkgmgr"
+	"github.com/spf13/cobra"
+)
+
+func upCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "up",
+		Short: "Starts all Docker containers",
+		Long:  `Starts all stopped Docker containers for installed packages in the current context.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pm, err := pkgmgr.NewDefaultPackageManager()
+			if err != nil {
+				slog.Error(fmt.Sprintf("failed to create package manager: %s", err))
+				os.Exit(1)
+			}
+			if err := pm.Up(); err != nil {
+				slog.Error(err.Error())
+				os.Exit(1)
+			}
+			return nil
+		},
+	}
+	return cmd
+}

--- a/pkgmgr/pkgmgr.go
+++ b/pkgmgr/pkgmgr.go
@@ -86,6 +86,31 @@ func (p *PackageManager) AvailablePackages() []Package {
 	return p.availablePackages[:]
 }
 
+func (p *PackageManager) Up() error {
+	// Find installed packages
+	installedPackages := p.InstalledPackages()
+	for _, tmpPackage := range installedPackages {
+		err := tmpPackage.Package.startService(p.config, tmpPackage.Context)
+		if err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (p *PackageManager) Down() error {
+	// Find installed packages
+	installedPackages := p.InstalledPackages()
+	for _, tmpPackage := range installedPackages {
+		err := tmpPackage.Package.stopService(p.config, tmpPackage.Context)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (p *PackageManager) InstalledPackages() []InstalledPackage {
 	var ret []InstalledPackage
 	for _, pkg := range p.state.InstalledPackages {


### PR DESCRIPTION
Fixes #14 
```
./cardano-up down
Stopping container cardano-node-8.7.3-default-cardano-node
➜  cardano-up git:(feat/start-stop) ✗ ./cardano-up up
Starting Docker container cardano-node-8.7.3-default-cardano-node
➜  cardano-up git:(feat/start-stop) ✗ ./cardano-up list
Installed packages (from context "default"):

Name                 Version      Context         Description
cardano-node         8.7.3        default         Cardano node software by Input Output Global
                                  default
```