### PR TITLE
feat: cardano-node data persistence

### DIFF
--- a/pkgmgr/config.go
+++ b/pkgmgr/config.go
@@ -22,20 +22,24 @@ import (
 )
 
 type Config struct {
-	ConfigDir string
+	BinDir    string
 	CacheDir  string
+	ConfigDir string
+	DataDir   string
 	Logger    *slog.Logger
 	Template  *Template
 }
 
 func NewDefaultConfig() (Config, error) {
-	userConfigDir, err := os.UserConfigDir()
+	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
 		return Config{}, fmt.Errorf(
-			"could not determine user config directory: %s",
+			"could not determine user home directory: %s",
 			err,
 		)
 	}
+	userBinDir := fmt.Sprintf("%s/.local/bin", userHomeDir)
+	userDataDir := fmt.Sprintf("%s/.local/share", userHomeDir)
 	userCacheDir, err := os.UserCacheDir()
 	if err != nil {
 		return Config{}, fmt.Errorf(
@@ -43,13 +47,25 @@ func NewDefaultConfig() (Config, error) {
 			err,
 		)
 	}
+	userConfigDir, err := os.UserConfigDir()
+	if err != nil {
+		return Config{}, fmt.Errorf(
+			"could not determine user config directory: %s",
+			err,
+		)
+	}
 	ret := Config{
+		BinDir: userBinDir,
+		CacheDir: filepath.Join(
+			userCacheDir,
+			"cardano-up",
+		),
 		ConfigDir: filepath.Join(
 			userConfigDir,
 			"cardano-up",
 		),
-		CacheDir: filepath.Join(
-			userCacheDir,
+		DataDir: filepath.Join(
+			userDataDir,
 			"cardano-up",
 		),
 		Logger: slog.Default(),

--- a/pkgmgr/config_test.go
+++ b/pkgmgr/config_test.go
@@ -99,8 +99,8 @@ func TestNewDefaultConfigXdgConfigCacheEnvVars(t *testing.T) {
 
 func TestNewDefaultConfigEmptyHome(t *testing.T) {
 	expectedErrs := map[string]string{
-		"linux":  "could not determine user config directory: neither $XDG_CONFIG_HOME nor $HOME are defined",
-		"darwin": "could not determine user config directory: $HOME is not defined",
+		"linux":  "could not determine user home directory: $HOME is not defined",
+		"darwin": "could not determine user home directory: $HOME is not defined",
 	}
 	origEnvVars := setEnvVars(
 		map[string]string{

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -40,8 +40,7 @@ func (p Package) install(cfg Config, context string) error {
 				"Version":   p.Version,
 			},
 			"DataDir": filepath.Join(
-				cfg.ConfigDir,
-				"data",
+				cfg.DataDir,
 				pkgName,
 			),
 		},
@@ -230,8 +229,7 @@ func (p *PackageInstallStepFile) install(cfg Config, pkgName string) error {
 		return err
 	}
 	filePath := filepath.Join(
-		cfg.ConfigDir,
-		"data",
+		cfg.DataDir,
 		pkgName,
 		tmpFilePath,
 	)
@@ -256,8 +254,7 @@ func (p *PackageInstallStepFile) install(cfg Config, pkgName string) error {
 
 func (p *PackageInstallStepFile) uninstall(cfg Config, pkgName string) error {
 	filePath := filepath.Join(
-		cfg.ConfigDir,
-		"data",
+		cfg.DataDir,
 		pkgName,
 		p.Filename,
 	)

--- a/pkgmgr/registry.go
+++ b/pkgmgr/registry.go
@@ -28,6 +28,9 @@ var RegistryPackages = []Package{
 						"NETWORK":                  "{{ .Context.Network }}",
 						"CARDANO_NODE_SOCKET_PATH": "/ipc/node.socket",
 					},
+					Binds: []string{
+						"{{ .DataDir }}/data:/data",
+					},
 					Ports: []string{
 						"3001",
 					},


### PR DESCRIPTION
This modifies some paths. We use ~/.local/share for data, which is the default location for XDG_DATA_HOME on Linux.