### PR TITLE
fix(package): fix config for Ogmios to match Context.Network 

### DIFF
--- a/packages/ogmios/ogmios-v6.1.0.yaml
+++ b/packages/ogmios/ogmios-v6.1.0.yaml
@@ -16,7 +16,7 @@ installSteps:
         - --node-socket
         - /ipc/node.socket
         - --node-config
-        - /config/mainnet/cardano-node/config.json
+        - /config/{{ .Context.Network }}/cardano-node/config.json
       binds:
         - '{{ .Paths.ContextDir }}/node-ipc:/ipc'
       ports:


### PR DESCRIPTION
```
94e402a597d3   ghcr.io/blinklabs-io/cardano-node:8.7.3   "/usr/local/bin/entr…"   20 minutes ago   Up 20 minutes             12788/tcp, 12798/tcp, 0.0.0.0:63598->3001/tcp   cardano-node-8.7.3-default-cardano-node
6d3d8942b3c9   cardanosolutions/ogmios:v6.1.0            "ogmios --log-level …"   20 minutes ago   Up 20 minutes (healthy)   0.0.0.0:60911->1337/tcp                         ogmios-v6.1.0-default-ogmios
```