### PR TITLE
feat(packages): add Kupo package

### DIFF
--- a/packages/cardano-node/cardano-node-8.9.1.yaml
+++ b/packages/cardano-node/cardano-node-8.9.1.yaml
@@ -23,6 +23,7 @@ outputs:
     description: Path to the Cardano Node UNIX socket
     value: '{{ .Paths.ContextDir }}/node-ipc/node.socket'
 preInstallScript: 'test -e {{ .Paths.DataDir }}/data/db/protocolMagicId && exit 0 || mithril-client cardano-db download --download-dir {{ .Paths.DataDir }}/data latest'
+postInstallScript: 'mkdir -p {{ .Paths.ContextDir }}/config && docker cp {{ .Package.Name }}-{{ .Package.ShortName }}:/opt/cardano/config/{{ .Context.Network }}/ {{ .Paths.ContextDir }}/config/'
 tags:
   - docker
   - linux

--- a/packages/kupo/kupo-2.8.0.yaml
+++ b/packages/kupo/kupo-2.8.0.yaml
@@ -1,0 +1,48 @@
+name: kupo
+version: 2.8.0
+description: Kupo is fast, lightweight and configurable chain-index for the Cardano blockchain
+dependencies:
+  - cardano-node >= 8.7.3
+installSteps:
+  - docker:
+      containerName: kupo
+      image: cardanosolutions/kupo:v2.8.0
+      command:
+        - kupo
+        - --node-socket
+        - /ipc/node.socket
+        - --host 
+        - 0.0.0.0
+        - --port 
+        - '1442'
+        - --log-level
+        - Info
+        - --node-config
+        - /config/config.json
+        - --match
+        - '*'
+        - --defer-db-indexes
+        - --since
+        - origin
+        - --workdir
+        - '/db'
+      binds:
+        - '{{ .Paths.ContextDir }}/node-ipc:/ipc'
+        - '{{ .Paths.DataDir }}/db:/db'
+        - '{{ .Paths.ContextDir }}/config/{{ .Context.Network }}:/config'
+      ports:
+        - "1442"
+      pullOnly: false
+outputs:
+  - name: url
+    description: Kupo API URL
+    value: 'http://localhost:{{ index (index .Ports "kupo") "1442" }}'
+  - name: health_url
+    description: Kupo health URL
+    value: 'http://localhost:{{ index (index .Ports "kupo") "1442" }}/health'
+tags:
+  - docker
+  - linux
+  - darwin
+  - amd64
+  - arm64


### PR DESCRIPTION
Test
```
docker ps -a
CONTAINER ID   IMAGE                                     COMMAND                  CREATED          STATUS                    PORTS                                           NAMES
be3bbaf1becb   cardanosolutions/kupo:2.8.0              "kupo --node-socket …"   13 seconds ago   Up 12 seconds (healthy)   0.0.0.0:64068->1442/tcp                         kupo-2.8.0-default-kupo
a26a935778ee   ghcr.io/blinklabs-io/cardano-node:8.9.1   "/usr/local/bin/entr…"   51 seconds ago   Up 46 seconds             12788/tcp, 12798/tcp, 0.0.0.0:63989->3001/tcp   cardano-node-8.9.1-default-cardano-node

 ./cardano-up context env | grep -i "KUPO"
export KUPO_HEALTH_URL=http://localhost:64068/health
export KUPO_URL=http://localhost:64068

curl -s http://localhost:64068/health
# TYPE kupo_configuration_indexes gauge
kupo_configuration_indexes  0.0
# TYPE kupo_connection_status gauge
kupo_connection_status  1.0
# TYPE kupo_most_recent_checkpoint counter
kupo_most_recent_checkpoint  11760261
# TYPE kupo_most_recent_node_tip counter
kupo_most_recent_node_tip  57360028
```

Closes #163 