### PR TITLE
fix: add pre-install and post-install

### DIFF
--- a/packages/cardano-node/cardano-node-8.9.2.yaml
+++ b/packages/cardano-node/cardano-node-8.9.2.yaml
@@ -28,6 +28,8 @@ outputs:
   - name: socket_path
     description: Path to the Cardano Node UNIX socket
     value: '{{ .Paths.ContextDir }}/node-ipc/node.socket'
+preInstallScript: 'test -e {{ .Paths.DataDir }}/data/db/protocolMagicId && exit 0 || mithril-client cardano-db download --download-dir {{ .Paths.DataDir }}/data latest'
+postInstallScript: 'mkdir -p {{ .Paths.ContextDir }}/config && docker cp {{ .Package.Name }}-{{ .Package.ShortName }}:/opt/cardano/config/{{ .Context.Network }}/ {{ .Paths.ContextDir }}/config/'
 tags:
   - docker
   - linux


### PR DESCRIPTION
This was missed when we upgraded to the 8.9.2 version of cardano-node. This restores it.