### PR TITLE
fix(packages): dolos outputs with static ports

### DIFF
--- a/packages/dolos/dolos-0.7.0.yaml
+++ b/packages/dolos/dolos-0.7.0.yaml
@@ -1,8 +1,6 @@
 name: dolos
 version: 0.7.0
-description: Description of dolos package
-dependencies:
-  - cardano-node >= 8.9.1
+description: Dolos is a Cardano data node
 installSteps:
   - docker:
       containerName: dolos
@@ -23,11 +21,11 @@ installSteps:
       source: files/daemon.toml.gotmpl
 outputs:
   - name: dolos-grpc
-    description: Dolos grpc service
-    value: 'http://localhost:{{ index (index .Ports "dolos") "50051" }}'
+    description: Dolos gRPC service
+    value: 'http://localhost:50051'
   - name: dolos-ouroboros
-    description: Dolos ouroboros service
-    value: 'http://localhost:{{ index (index .Ports "dolos") "30013" }}'
+    description: Dolos Ouroboros Node-to-Node service
+    value: 'localhost:30013'
 tags:
   - docker
   - linux

--- a/packages/dolos/files/daemon.toml.gotmpl
+++ b/packages/dolos/files/daemon.toml.gotmpl
@@ -25,7 +25,7 @@ prune_height = 10000
 listen_address = "[::]:50051"
  
 [serve.ouroboros]
-listen_address = "localhost:30013"
+listen_address = "[::]:30013"
 # https://github.com/txpipe/dolos/blob/main/examples/sync-mainnet/dolos.toml#L26
 magic = 0
  


### PR DESCRIPTION
This closes #209 but also removes the dependency on a local cardano-node, as it's not necessary for Dolos.