### PR TITLE
fix: dolos start and persistence

### DIFF
--- a/packages/dolos/dolos-0.7.0.yaml
+++ b/packages/dolos/dolos-0.7.0.yaml
@@ -1,6 +1,8 @@
 name: dolos
 version: 0.7.0
 description: Dolos is a Cardano data node
+dependencies:
+  - cardano-config >= 20240515
 installSteps:
   - docker:
       containerName: dolos
@@ -9,11 +11,12 @@ installSteps:
         - dolos
         - daemon
       binds:
-        - '{{ .Paths.DataDir }}/:/etc/dolos/'
+        - '{{ .Paths.DataDir }}:/etc/dolos'
+        - '{{ .Paths.DataDir }}/data:/data'
         - '{{ .Paths.ContextDir }}/config/{{ .Context.Network }}:/config'
       ports:
-        - "30013"
-        - "50051"
+        - "30013:30013"
+        - "50051:50051"
       pullOnly: false
   - file:
       binary: true

--- a/packages/dolos/files/daemon.toml.gotmpl
+++ b/packages/dolos/files/daemon.toml.gotmpl
@@ -2,10 +2,14 @@
 [upstream]
 peer_address = "{{ .Context.Network }}-node.world.dev.cardano.org:30000"
 network_magic = {{ .Context.NetworkMagic }}
+{{- if eq .Context.Network "mainnet" }}
+is_testnet = false
+{{ else }}
 is_testnet = true
+{{- end }}
  
 [storage]
-path = "./tmp/data"
+path = "/data"
 wal_size = 1000
  
 [genesis]
@@ -27,7 +31,7 @@ listen_address = "[::]:50051"
 [serve.ouroboros]
 listen_address = "[::]:30013"
 # https://github.com/txpipe/dolos/blob/main/examples/sync-mainnet/dolos.toml#L26
-magic = 0
+magic = {{ .Context.NetworkMagic }}
  
 [logging]
 max_level = "debug"


### PR DESCRIPTION
A few quick changes

- depend on cardano-configs
- add a /data persistent per-version directory and update config
- use static host ports (see #231)
- serve correct ouroboros network magic

Closes #27 