### PR TITLE
fix: map ports as exposed ports always

### DIFF
--- a/pkgmgr/docker.go
+++ b/pkgmgr/docker.go
@@ -174,6 +174,13 @@ func (d *DockerService) Create() error {
 	if err != nil {
 		return err
 	}
+
+	// Create a new PortSet to expose all ports
+	exposePorts := make(nat.PortSet)
+	for port := range tmpPorts {
+		exposePorts[port] = struct{}{}
+	}
+
 	// Set the desired user ID and group ID
 	userID := os.Getuid()
 	groupID := os.Getgid()
@@ -183,12 +190,13 @@ func (d *DockerService) Create() error {
 	resp, err := client.ContainerCreate(
 		context.Background(),
 		&container.Config{
-			Hostname:   d.ContainerName,
-			Image:      d.Image,
-			Entrypoint: d.Command,
-			Cmd:        d.Args,
-			Env:        tmpEnv[:],
-			User:       userAndGroup,
+			Hostname:     d.ContainerName,
+			Image:        d.Image,
+			Entrypoint:   d.Command,
+			Cmd:          d.Args,
+			Env:          tmpEnv[:],
+			User:         userAndGroup,
+			ExposedPorts: exposePorts,
 		},
 		&container.HostConfig{
 			RestartPolicy: container.RestartPolicy{


### PR DESCRIPTION
This probably isn't the correct way to do this, but it worked in all my tests and we don't really care about the actual exposed ports. This should also work for the case where we use ports which weren't originally exposed in the image.

This is related to #209 and why we weren't getting all of our ports. They weren't getting mapped into the container correctly. This solves that issue correctly and closes #231.