### PR TITLE
fix(packages): dolos reorder steps to resolve start issue

### DIFF
--- a/packages/dolos/dolos-0.7.0.yaml
+++ b/packages/dolos/dolos-0.7.0.yaml
@@ -4,6 +4,9 @@ description: Dolos is a Cardano data node
 dependencies:
   - cardano-config >= 20240515
 installSteps:
+  - file:
+      filename: daemon.toml
+      source: files/daemon.toml.gotmpl
   - docker:
       containerName: dolos
       image: ghcr.io/txpipe/dolos:v0.7.0
@@ -15,20 +18,16 @@ installSteps:
         - '{{ .Paths.DataDir }}/data:/data'
         - '{{ .Paths.ContextDir }}/config/{{ .Context.Network }}:/config'
       ports:
-        - "30013:30013"
-        - "50051:50051"
+        - "30013"
+        - "50051"
       pullOnly: false
-  - file:
-      binary: true
-      filename: daemon.toml
-      source: files/daemon.toml.gotmpl
 outputs:
-  - name: dolos-grpc
+  - name: grpc
     description: Dolos gRPC service
-    value: 'http://localhost:50051'
-  - name: dolos-ouroboros
+    value: 'http://localhost:{{ index (index .Ports "dolos") "50051" }}'
+  - name: ouroboros-ntn
     description: Dolos Ouroboros Node-to-Node service
-    value: 'localhost:30013'
+    value: 'localhost:{{ index (index .Ports "dolos") "30013" }}'
 tags:
   - docker
   - linux


### PR DESCRIPTION
This resolves the issue with Dolos starting up.

- Write config file before starting container
- Remove static host port mapping to allow multiple instances
- Remove redundant `dolos-` prefix from output names
- Restore port lookup to get local port, requires #237 and reverts #226 

Closes #227 