### PR TITLE
fix: check for parent dir reference when extracting cache

### DIFF
--- a/pkgmgr/registry.go
+++ b/pkgmgr/registry.go
@@ -170,6 +170,10 @@ func registryPackagesUrl(cfg Config, validate bool) ([]Package, error) {
 			if (zipFile.Mode() & fs.ModeDir) > 0 {
 				continue
 			}
+			// Ensure there are no parent dir references in path
+			if strings.Contains(zipFile.Name, "..") {
+				continue
+			}
 			outPath := filepath.Join(
 				cachePath,
 				zipFile.Name,


### PR DESCRIPTION
Fixes #235