### PR TITLE
feat: expose the bin directory to packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Package manifest files are evaluated as a Go template before being parsed as YAM
 | `.Package.Version` | Package version |
 | `.Package.Options` | Provided package options |
 | `.Paths` | |
+| `.Paths.BinDir` | Binary dir for package |
 | `.Paths.CacheDir` | Cache dir for package |
 | `.Paths.ContextDir` | Context dir for package |
 | `.Paths.DataDir` | Data dir for package |

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -135,6 +135,7 @@ func (p Package) install(
 				"Options":   opts,
 			},
 			"Paths": map[string]string{
+				"BinDir":     cfg.BinDir,
 				"CacheDir":   pkgCacheDir,
 				"ContextDir": pkgContextDir,
 				"DataDir":    pkgDataDir,


### PR DESCRIPTION
This will allow us to use the full path to binaries from packages we ship, ensuring they execute correctly in environments where the user has not modified their path.