### PR TITLE
feat(pkgmgr): expose os facts to packages

### DIFF
--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -26,6 +26,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"github.com/hashicorp/go-version"
@@ -141,6 +142,10 @@ func (p Package) install(
 				"CacheDir":   pkgCacheDir,
 				"ContextDir": pkgContextDir,
 				"DataDir":    pkgDataDir,
+			},
+			"System": map[string]string{
+				"OS":   runtime.GOOS,
+				"ARCH": runtime.GOARCH,
 			},
 		},
 	)

--- a/pkgmgr/package_test.go
+++ b/pkgmgr/package_test.go
@@ -16,8 +16,10 @@ package pkgmgr
 
 import (
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
+	"text/template"
 
 	"gopkg.in/yaml.v3"
 )
@@ -66,5 +68,66 @@ func TestPackageToYaml(t *testing.T) {
 				testDef.yaml,
 			)
 		}
+	}
+}
+
+func TestOSAndARCH(t *testing.T) {
+	expectOS := runtime.GOOS
+	expectARCH := runtime.GOARCH
+
+	// Initialized a config object
+	tempCacheDir := t.TempDir()
+	tempDataDir := t.TempDir()
+	cfg := Config{
+		CacheDir: tempCacheDir,
+		DataDir:  tempDataDir,
+		BinDir:   "/usr/local/bin",
+		Template: &Template{
+			tmpl:     template.New("test"),
+			baseVars: make(map[string]any),
+		},
+	}
+
+	cfg.Template = cfg.Template.WithVars(
+		map[string]any{
+			"System": map[string]string{
+				"OS":   runtime.GOOS,
+				"ARCH": runtime.GOARCH,
+			},
+		},
+	)
+
+	// Defined a test package
+	pkg := Package{}
+	pkg.Name = "test-package"
+	pkg.Version = "1.0.0"
+	opts := make(map[string]bool)
+
+	_, _, err := pkg.install(cfg, "test", opts, false)
+	if err != nil {
+		t.Errorf("Installation failed: %v", err)
+	}
+
+	// Verify if OS and ARCH are injected into the config template
+	actualOS, err := cfg.Template.Render("{{ .System.OS }}", nil)
+	if err != nil {
+		t.Errorf("Template rendering for OS failed: %v", err)
+	} else if actualOS != expectOS {
+		t.Errorf("Expected OS: %s and rendered OS: %s are not same", expectOS, actualOS)
+	} else {
+		t.Logf("Expected OS matched with rendered OS")
+	}
+
+	actualARCH, err := cfg.Template.Render("{{ .System.ARCH }}", nil)
+	if err != nil {
+		t.Errorf("Template rendering for ARCH failed: %v", err)
+	} else if actualARCH != expectARCH {
+		t.Errorf("Expected ARCH: %s and rendered ARCH: %s are not same", expectARCH, actualARCH)
+	} else {
+		t.Logf("Expected ARCH matched with rendered ARCH")
+	}
+
+	if actualOS == expectOS && actualARCH == expectARCH {
+		t.Logf("Test is successful and OS, ARCH values are correctly injected to config template")
 	}
 }


### PR DESCRIPTION
1. Exposes the OS and ARCH as template variables, making them available for package configurations.
2. Written an unit test function to validate proper injection of OS & ARCH into the template during installation.

Closes #343 