### PR TITLE
fix(pkgmgr): tighten up permissions on directories and files

### DIFF
--- a/pkgmgr/state.go
+++ b/pkgmgr/state.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Blink Labs Software
+// Copyright 2025 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ func (s *State) saveFile(filename string, src any) error {
 	// Create parent directory if it doesn't exist
 	if _, err := os.Stat(s.config.ConfigDir); err != nil {
 		if os.IsNotExist(err) {
-			if err := os.MkdirAll(s.config.ConfigDir, os.ModePerm); err != nil {
+			if err := os.MkdirAll(s.config.ConfigDir, 0700); err != nil {
 				return err
 			}
 		}
@@ -107,7 +107,7 @@ func (s *State) saveFile(filename string, src any) error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(tmpPath, yamlContent, os.ModePerm); err != nil {
+	if err := os.WriteFile(tmpPath, yamlContent, 0600); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Previously, we relied on the user's umask setting to ensure safety, but it's better to be explicit.