### PR TITLE
fix(lint): changes to fix golangci lint errors

### DIFF
--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -981,7 +981,7 @@ func (p *PackageInstallStepFile) install(
 	} else {
 		return errors.New("packages must provide content, source, or url for file install types")
 	}
-	if err := os.WriteFile(filePath, fileContent, fileMode); err != nil {
+	if err := os.WriteFile(filePath, fileContent, fileMode); err != nil { //nolint:gosec // path traversal mitigated by prefix check above
 		return err
 	}
 	cfg.Logger.Debug("wrote file " + filePath)

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -914,6 +914,11 @@ func (p *PackageInstallStepFile) install(
 		pkgName,
 		tmpFilePath,
 	)
+	filePath = filepath.Clean(filePath)
+	expectedPrefix := filepath.Clean(filepath.Join(cfg.DataDir, pkgName)) + string(os.PathSeparator)
+	if !strings.HasPrefix(filePath, expectedPrefix) {
+		return fmt.Errorf("invalid file path %q: path traversal detected", filePath)
+	}
 	parentDir := filepath.Dir(filePath)
 	if err := os.MkdirAll(parentDir, fs.ModePerm); err != nil {
 		return err


### PR DESCRIPTION
closes #503 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent path traversal in package file installation by normalizing paths and enforcing a safe directory prefix. Adds a targeted `//nolint:gosec` on the validated write to resolve golangci-lint warnings.

- **Bug Fixes**
  - Clean `filePath`, compute `expectedPrefix` via `filepath.Join(cfg.DataDir, pkgName)` with a trailing `os.PathSeparator`, and error on mismatch.
  - Create parent dirs only after validation; annotate `os.WriteFile` with `//nolint:gosec` since traversal is blocked.

<sup>Written for commit f249cb0ac4133b5f192565e993325e0594779b39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a path traversal vulnerability in file installation to ensure files are written to the correct, intended location within the package data directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->