### PR TITLE
feat: CLI flag to target a context per-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ of the node.
 
 Commands such as `install`, `uninstall`, and `list` work in the active context. You can use the `context` command to change the active context or manage available contexts.
 
+### Targeting a context per command
+
+By default, commands operate on the active context. You can target a different context for a single invocation with the global `--context` (`-c`) flag, without changing the active context shared across your shells:
+
+```
+cardano-up --context my-project up
+cardano-up --context my-project logs cardano-node
+eval $(cardano-up --context my-project context env)
+```
+
+This is useful when several projects each drive their own stack on the same machine. The `--context` flag is honored by the lifecycle and query commands (`up`/`start`, `down`/`stop`, `install`, `uninstall`, `upgrade`, `logs`, `info`, `list`, and `context env`). It cannot be combined with the context management commands (`context select`, `context create`, `context delete`), which manage the persisted active context itself.
+
 ## Command reference
 
 The `cardano-up` command consists of multiple subcommands. You can list all subcommands by running `cardano-up` with no arguments or with the `--help` option.
@@ -101,9 +113,10 @@ Available Commands:
   version        Displays the version
 
 Flags:
-  -D, --debug   enable debug logging
-  -h, --help    help for cardano-up
-  -v, --verbose Show all available versions of packages
+  -c, --context string   target the named context for this command instead of the active one
+  -D, --debug            enable debug logging
+  -h, --help             help for cardano-up
+  -v, --verbose          Show all available versions of packages
 
 Use "cardano-up [command] --help" for more information about a command.
 ```

--- a/cmd/cardano-up/context.go
+++ b/cmd/cardano-up/context.go
@@ -31,6 +31,15 @@ var contextFlags = struct {
 	force       bool
 }{}
 
+func rejectContextOverride(cmd *cobra.Command, args []string) error {
+	if globalFlags.context != "" {
+		return errors.New(
+			"--context cannot be used with context management commands",
+		)
+	}
+	return nil
+}
+
 func contextCommand() *cobra.Command {
 	contextCommand := &cobra.Command{
 		Use:   "context",
@@ -92,8 +101,9 @@ func contextListCommand() *cobra.Command {
 
 func contextSelectCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "select <context name>",
-		Short: "Select the active context",
+		Use:     "select <context name>",
+		Short:   "Select the active context",
+		PreRunE: rejectContextOverride,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return errors.New("no context name provided")
@@ -121,8 +131,9 @@ func contextSelectCommand() *cobra.Command {
 
 func contextCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "create <context name>",
-		Short: "Create a new context",
+		Use:     "create <context name>",
+		Short:   "Create a new context",
+		PreRunE: rejectContextOverride,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return errors.New("no context name provided")
@@ -154,8 +165,9 @@ func contextCreateCommand() *cobra.Command {
 
 func contextDeleteCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete <context name>",
-		Short: "Delete a context",
+		Use:     "delete <context name>",
+		Short:   "Delete a context",
+		PreRunE: rejectContextOverride,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return errors.New("no context name provided")

--- a/cmd/cardano-up/install.go
+++ b/cmd/cardano-up/install.go
@@ -54,11 +54,11 @@ func installCommand() *cobra.Command {
 
 func installCommandRun(cmd *cobra.Command, args []string) {
 	pm := createPackageManager()
-	activeContextName, activeContext := pm.ActiveContext()
+	contextName, context := pm.EffectiveContext()
 	// Update context network if specified
 	if installFlags.network != "" {
-		activeContext.Network = installFlags.network
-		if err := pm.UpdateContext(activeContextName, activeContext); err != nil {
+		context.Network = installFlags.network
+		if err := pm.UpdateContext(contextName, context); err != nil {
 			slog.Error(err.Error())
 			os.Exit(1)
 		}
@@ -70,9 +70,9 @@ func installCommandRun(cmd *cobra.Command, args []string) {
 		)
 	}
 	// Check that context network is set
-	if activeContext.Network == "" {
-		activeContext.Network = defaultNetwork
-		if err := pm.UpdateContext(activeContextName, activeContext); err != nil {
+	if context.Network == "" {
+		context.Network = defaultNetwork
+		if err := pm.UpdateContext(contextName, context); err != nil {
 			slog.Error(err.Error())
 			os.Exit(1)
 		}
@@ -80,7 +80,7 @@ func installCommandRun(cmd *cobra.Command, args []string) {
 			fmt.Sprintf(
 				"defaulting to network %q for context %q",
 				defaultNetwork,
-				activeContextName,
+				contextName,
 			),
 		)
 	}

--- a/cmd/cardano-up/install.go
+++ b/cmd/cardano-up/install.go
@@ -64,8 +64,9 @@ func installCommandRun(cmd *cobra.Command, args []string) {
 		}
 		slog.Debug(
 			fmt.Sprintf(
-				"set active context network to %q",
+				"set network to %q for context %q",
 				installFlags.network,
+				contextName,
 			),
 		)
 	}

--- a/cmd/cardano-up/list.go
+++ b/cmd/cardano-up/list.go
@@ -83,14 +83,14 @@ func listCommand() *cobra.Command {
 		Short: "List installed packages",
 		Run: func(cmd *cobra.Command, args []string) {
 			pm := createPackageManager()
-			activeContextName, _ := pm.ActiveContext()
+			contextName, _ := pm.EffectiveContext()
 			var packages []pkgmgr.InstalledPackage
 			if listFlags.all {
 				packages = pm.InstalledPackagesAllContexts()
 				slog.Info("Installed packages (all contexts):\n")
 			} else {
 				packages = pm.InstalledPackages()
-				slog.Info(fmt.Sprintf("Installed packages (from context %q):\n", activeContextName))
+				slog.Info(fmt.Sprintf("Installed packages (from context %q):\n", contextName))
 			}
 			if len(packages) > 0 {
 				slog.Info(

--- a/cmd/cardano-up/main.go
+++ b/cmd/cardano-up/main.go
@@ -28,11 +28,12 @@ const (
 	programName = "cardano-up"
 )
 
-func main() {
-	globalFlags := struct {
-		debug bool
-	}{}
+var globalFlags = struct {
+	debug   bool
+	context string
+}{}
 
+func main() {
 	rootCmd := &cobra.Command{
 		Use: programName,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
@@ -53,6 +54,8 @@ func main() {
 	// Global flags
 	rootCmd.PersistentFlags().
 		BoolVarP(&globalFlags.debug, "debug", "D", false, "enable debug logging")
+	rootCmd.PersistentFlags().
+		StringVarP(&globalFlags.context, "context", "c", "", "target the named context for this command instead of the active one")
 
 	// Add subcommands
 	rootCmd.AddCommand(
@@ -96,6 +99,20 @@ func createPackageManager() *pkgmgr.PackageManager {
 	if err != nil {
 		slog.Error(fmt.Sprintf("failed to create package manager: %s", err))
 		os.Exit(1)
+	}
+	// Apply per-invocation context override (--context) without mutating the
+	// persisted active context
+	if globalFlags.context != "" {
+		if err := pm.SetActiveContextOverride(globalFlags.context); err != nil {
+			slog.Error(
+				fmt.Sprintf(
+					"invalid --context %q: %s",
+					globalFlags.context,
+					err,
+				),
+			)
+			os.Exit(1)
+		}
 	}
 	return pm
 }

--- a/pkgmgr/context_override_test.go
+++ b/pkgmgr/context_override_test.go
@@ -1,0 +1,114 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkgmgr
+
+import (
+	"errors"
+	"testing"
+)
+
+func newTestPackageManager() *PackageManager {
+	return &PackageManager{
+		config: Config{},
+		state: &State{
+			ActiveContext: "default",
+			Contexts: map[string]Context{
+				"default": {Network: "preprod"},
+				"other":   {Network: "preview"},
+			},
+			InstalledPackages: []InstalledPackage{
+				{
+					Package: Package{Name: "foo", Version: "1.0.0"},
+					Context: "default",
+					Outputs: map[string]string{"FOO": "default"},
+				},
+				{
+					Package: Package{Name: "bar", Version: "2.0.0"},
+					Context: "other",
+					Outputs: map[string]string{"BAR": "other"},
+				},
+			},
+		},
+	}
+}
+
+func TestInstalledPackagesUsesActiveContextByDefault(t *testing.T) {
+	pm := newTestPackageManager()
+	pkgs := pm.InstalledPackages()
+	if len(pkgs) != 1 || pkgs[0].Package.Name != "foo" {
+		t.Fatalf(
+			"expected only the active context (default) package, got: %#v",
+			pkgs,
+		)
+	}
+}
+
+func TestSetActiveContextOverrideTargetsOtherContext(t *testing.T) {
+	pm := newTestPackageManager()
+	if err := pm.SetActiveContextOverride("other"); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	// InstalledPackages now reflects the override
+	pkgs := pm.InstalledPackages()
+	if len(pkgs) != 1 || pkgs[0].Package.Name != "bar" {
+		t.Fatalf(
+			"expected only the overridden context (other) package, got: %#v",
+			pkgs,
+		)
+	}
+	// EffectiveContext reflects the override
+	name, ctx := pm.EffectiveContext()
+	if name != "other" || ctx.Network != "preview" {
+		t.Fatalf("expected effective context other/preview, got %q/%q", name, ctx.Network)
+	}
+	// ContextEnv reflects the override
+	env := pm.ContextEnv()
+	if env["BAR"] != "other" {
+		t.Fatalf("expected env from overridden context, got: %#v", env)
+	}
+	if _, ok := env["FOO"]; ok {
+		t.Fatalf("did not expect env from active context, got: %#v", env)
+	}
+}
+
+func TestSetActiveContextOverrideDoesNotMutateActiveContext(t *testing.T) {
+	pm := newTestPackageManager()
+	if err := pm.SetActiveContextOverride("other"); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	// The persisted active context must be unchanged
+	if pm.state.ActiveContext != "default" {
+		t.Fatalf(
+			"override must not mutate persisted active context, got %q",
+			pm.state.ActiveContext,
+		)
+	}
+	name, _ := pm.ActiveContext()
+	if name != "default" {
+		t.Fatalf("ActiveContext must still return default, got %q", name)
+	}
+}
+
+func TestSetActiveContextOverrideUnknownContext(t *testing.T) {
+	pm := newTestPackageManager()
+	err := pm.SetActiveContextOverride("nope")
+	if !errors.Is(err, ErrContextNotExist) {
+		t.Fatalf("expected ErrContextNotExist, got: %v", err)
+	}
+	// A failed override must leave targeting on the active context
+	if pm.contextOverride != "" {
+		t.Fatalf("failed override must not set contextOverride, got %q", pm.contextOverride)
+	}
+}

--- a/pkgmgr/pkgmgr.go
+++ b/pkgmgr/pkgmgr.go
@@ -30,6 +30,7 @@ type PackageManager struct {
 	config            Config
 	state             *State
 	availablePackages []Package
+	contextOverride   string
 }
 
 func NewPackageManager(cfg Config) (*PackageManager, error) {
@@ -65,12 +66,12 @@ func (p *PackageManager) init() error {
 }
 
 func (p *PackageManager) initTemplate() {
-	activeContextName, activeContext := p.ActiveContext()
+	contextName, context := p.effectiveContext()
 	tmplVars := map[string]any{
 		"Context": map[string]any{
-			"Name":         activeContextName,
-			"Network":      activeContext.Network,
-			"NetworkMagic": activeContext.NetworkMagic,
+			"Name":         contextName,
+			"Network":      context.Network,
+			"NetworkMagic": context.NetworkMagic,
 		},
 		"Env": p.ContextEnv(),
 	}
@@ -140,9 +141,10 @@ func (p *PackageManager) Down() error {
 }
 
 func (p *PackageManager) InstalledPackages() []InstalledPackage {
+	contextName, _ := p.effectiveContext()
 	var ret []InstalledPackage
 	for _, pkg := range p.state.InstalledPackages {
-		if pkg.Context == p.state.ActiveContext {
+		if pkg.Context == contextName {
 			ret = append(ret, pkg)
 		}
 	}
@@ -155,14 +157,14 @@ func (p *PackageManager) InstalledPackagesAllContexts() []InstalledPackage {
 
 func (p *PackageManager) Install(pkgs ...string) error {
 	// Check context for network
-	activeContextName, activeContext := p.ActiveContext()
-	if activeContext.Network == "" {
+	contextName, context := p.effectiveContext()
+	if context.Network == "" {
 		return ErrContextInstallNoNetwork
 	}
 	resolver, err := NewResolver(
 		p.InstalledPackages(),
 		p.AvailablePackages(),
-		activeContextName,
+		contextName,
 		p.config.Logger,
 	)
 	if err != nil {
@@ -186,10 +188,10 @@ func (p *PackageManager) Install(pkgs ...string) error {
 		tmpPkgOpts := installPkg.Install.defaultOpts()
 		maps.Copy(tmpPkgOpts, installPkg.Options)
 		// Install package
-		registeredPorts := p.registeredPorts(activeContextName, installPkg.Install.Name)
+		registeredPorts := p.registeredPorts(contextName, installPkg.Install.Name)
 		notes, outputs, usedPorts, err := installPkg.Install.install(
 			p.config,
-			activeContextName,
+			contextName,
 			tmpPkgOpts,
 			true,
 			registeredPorts,
@@ -199,7 +201,7 @@ func (p *PackageManager) Install(pkgs ...string) error {
 		}
 		installedPkg := NewInstalledPackage(
 			installPkg.Install,
-			activeContextName,
+			contextName,
 			notes,
 			outputs,
 			tmpPkgOpts,
@@ -208,7 +210,7 @@ func (p *PackageManager) Install(pkgs ...string) error {
 			p.state.InstalledPackages,
 			installedPkg,
 		)
-		p.setRegisteredPorts(activeContextName, installPkg.Install.Name, usedPorts)
+		p.setRegisteredPorts(contextName, installPkg.Install.Name, usedPorts)
 		if err := p.state.Save(); err != nil {
 			return err
 		}
@@ -223,7 +225,7 @@ func (p *PackageManager) Install(pkgs ...string) error {
 			sb.WriteString("\n")
 		}
 		// Activate package
-		if err := installPkg.Install.activate(p.config, activeContextName); err != nil {
+		if err := installPkg.Install.activate(p.config, contextName); err != nil {
 			p.config.Logger.Warn(
 				fmt.Sprintf("failed to activate package: %s", err),
 			)
@@ -237,7 +239,7 @@ func (p *PackageManager) Install(pkgs ...string) error {
 	p.config.Logger.Info(
 		fmt.Sprintf(
 			"Successfully installed package(s) in context %q: %s",
-			activeContextName,
+			contextName,
 			strings.Join(installedPkgs, ", "),
 		),
 	)
@@ -245,11 +247,11 @@ func (p *PackageManager) Install(pkgs ...string) error {
 }
 
 func (p *PackageManager) Upgrade(pkgs ...string) error {
-	activeContextName, _ := p.ActiveContext()
+	contextName, _ := p.effectiveContext()
 	resolver, err := NewResolver(
 		p.InstalledPackages(),
 		p.AvailablePackages(),
-		activeContextName,
+		contextName,
 		p.config.Logger,
 	)
 	if err != nil {
@@ -272,9 +274,9 @@ func (p *PackageManager) Upgrade(pkgs ...string) error {
 		)
 		// Capture options from existing package
 		pkgOpts := upgradePkg.Installed.Options
-		registeredPorts := p.registeredPorts(activeContextName, upgradePkg.Installed.Package.Name)
+		registeredPorts := p.registeredPorts(contextName, upgradePkg.Installed.Package.Name)
 		// Deactivate old package
-		if err := upgradePkg.Installed.Package.deactivate(p.config, activeContextName); err != nil {
+		if err := upgradePkg.Installed.Package.deactivate(p.config, contextName); err != nil {
 			p.config.Logger.Warn(
 				fmt.Sprintf("failed to deactivate package: %s", err),
 			)
@@ -286,7 +288,7 @@ func (p *PackageManager) Upgrade(pkgs ...string) error {
 		// Install new version
 		notes, outputs, usedPorts, err := upgradePkg.Upgrade.install(
 			p.config,
-			activeContextName,
+			contextName,
 			pkgOpts,
 			false,
 			registeredPorts,
@@ -296,7 +298,7 @@ func (p *PackageManager) Upgrade(pkgs ...string) error {
 		}
 		installedPkg := NewInstalledPackage(
 			upgradePkg.Upgrade,
-			activeContextName,
+			contextName,
 			notes,
 			outputs,
 			pkgOpts,
@@ -305,7 +307,7 @@ func (p *PackageManager) Upgrade(pkgs ...string) error {
 			p.state.InstalledPackages,
 			installedPkg,
 		)
-		p.setRegisteredPorts(activeContextName, upgradePkg.Upgrade.Name, usedPorts)
+		p.setRegisteredPorts(contextName, upgradePkg.Upgrade.Name, usedPorts)
 		if err := p.state.Save(); err != nil {
 			return err
 		}
@@ -323,7 +325,7 @@ func (p *PackageManager) Upgrade(pkgs ...string) error {
 			return err
 		}
 		// Activate new package
-		if err := upgradePkg.Upgrade.activate(p.config, activeContextName); err != nil {
+		if err := upgradePkg.Upgrade.activate(p.config, contextName); err != nil {
 			p.config.Logger.Warn(
 				fmt.Sprintf("failed to activate package: %s", err),
 			)
@@ -336,7 +338,7 @@ func (p *PackageManager) Upgrade(pkgs ...string) error {
 	p.config.Logger.Info(
 		fmt.Sprintf(
 			"Successfully upgraded/installed package(s) in context %q: %s",
-			activeContextName,
+			contextName,
 			strings.Join(installedPkgs, ", "),
 		),
 	)
@@ -349,7 +351,7 @@ func (p *PackageManager) Uninstall(
 	force bool,
 ) error {
 	// Find installed packages
-	activeContextName, _ := p.ActiveContext()
+	contextName, _ := p.effectiveContext()
 	installedPackages := p.InstalledPackages()
 	var uninstallPkgs []InstalledPackage
 	foundPackage := false
@@ -364,14 +366,14 @@ func (p *PackageManager) Uninstall(
 		}
 	}
 	if !foundPackage {
-		return NewPackageNotInstalledError(pkgName, activeContextName)
+		return NewPackageNotInstalledError(pkgName, contextName)
 	}
 	if !force {
 		// Resolve dependencies
 		resolver, err := NewResolver(
 			p.InstalledPackages(),
 			p.AvailablePackages(),
-			activeContextName,
+			contextName,
 			p.config.Logger,
 		)
 		if err != nil {
@@ -383,7 +385,7 @@ func (p *PackageManager) Uninstall(
 	}
 	for _, uninstallPkg := range uninstallPkgs {
 		// Deactivate package
-		if err := uninstallPkg.Package.deactivate(p.config, activeContextName); err != nil {
+		if err := uninstallPkg.Package.deactivate(p.config, contextName); err != nil {
 			p.config.Logger.Warn(
 				fmt.Sprintf("failed to deactivate package: %s", err),
 			)
@@ -399,7 +401,7 @@ func (p *PackageManager) Uninstall(
 				"Successfully uninstalled package %s (= %s) from context %q",
 				uninstallPkg.Package.Name,
 				uninstallPkg.Package.Version,
-				activeContextName,
+				contextName,
 			),
 		)
 	}
@@ -414,7 +416,7 @@ func (p *PackageManager) Logs(
 	stderrWriter io.Writer,
 ) error {
 	// Find installed packages
-	activeContextName, _ := p.ActiveContext()
+	contextName, _ := p.effectiveContext()
 	installedPackages := p.InstalledPackages()
 	var logsPkg InstalledPackage
 	foundPackage := false
@@ -426,9 +428,9 @@ func (p *PackageManager) Logs(
 		}
 	}
 	if !foundPackage {
-		return NewPackageNotInstalledError(pkgName, activeContextName)
+		return NewPackageNotInstalledError(pkgName, contextName)
 	}
-	services, err := logsPkg.Package.services(p.config, activeContextName)
+	services, err := logsPkg.Package.services(p.config, contextName)
 	if err != nil {
 		return err
 	}
@@ -445,7 +447,7 @@ func (p *PackageManager) Logs(
 
 func (p *PackageManager) Info(pkgs ...string) error {
 	// Find installed packages
-	activeContextName, _ := p.ActiveContext()
+	contextName, _ := p.effectiveContext()
 	installedPackages := p.InstalledPackages()
 	var infoPkgs []InstalledPackage
 	for _, pkg := range pkgs {
@@ -461,7 +463,7 @@ func (p *PackageManager) Info(pkgs ...string) error {
 			}
 		}
 		if !foundPackage {
-			return NewPackageNotInstalledError(pkg, activeContextName)
+			return NewPackageNotInstalledError(pkg, contextName)
 		}
 	}
 	var sb strings.Builder
@@ -471,7 +473,7 @@ func (p *PackageManager) Info(pkgs ...string) error {
 		sb.WriteString("\nVersion: ")
 		sb.WriteString(infoPkg.Package.Version)
 		sb.WriteString("\nContext: ")
-		sb.WriteString(activeContextName)
+		sb.WriteString(contextName)
 		if infoPkg.PostInstallNotes != "" {
 			sb.WriteString(
 				"\n\nPost-install notes:\n\n" + infoPkg.PostInstallNotes,
@@ -574,6 +576,30 @@ func (p *PackageManager) Contexts() map[string]Context {
 
 func (p *PackageManager) ActiveContext() (string, Context) {
 	return p.state.ActiveContext, p.state.Contexts[p.state.ActiveContext]
+}
+
+// Returns the context targeted by this PackageManager.
+func (p *PackageManager) effectiveContext() (string, Context) {
+	if p.contextOverride != "" {
+		return p.contextOverride, p.state.Contexts[p.contextOverride]
+	}
+	return p.state.ActiveContext, p.state.Contexts[p.state.ActiveContext]
+}
+
+func (p *PackageManager) EffectiveContext() (string, Context) {
+	return p.effectiveContext()
+}
+
+// SetActiveContextOverride targets the named context for the lifetime of this
+// PackageManager instance without mutating the persisted effective context.
+func (p *PackageManager) SetActiveContextOverride(name string) error {
+	if _, ok := p.state.Contexts[name]; !ok {
+		return ErrContextNotExist
+	}
+	p.contextOverride = name
+	// Rebuild templating values so they reflect the target context
+	p.initTemplate()
+	return nil
 }
 
 func (p *PackageManager) AddContext(name string, context Context) error {


### PR DESCRIPTION
Hi team! This closes #294 and solves an issue I'm experiencing integrating `cardano-up` with [cardano-init](https://github.com/input-output-hk/cardano-init). I went straight to implementing because I saw @wolf31o2 had already opened #294. I hope it's ok, and I'm available to make any changes you might require.

## Summary

Adds a persistent global `--context`/`-c` flag that lets any command operate on a named context for a single invocation, without changing the persisted active context (`active_context.yaml`).

```
cardano-up --context my-project up
cardano-up --context my-project logs cardano-node
eval $(cardano-up --context my-project context env)
```

## Motivation

Today, every lifecycle and query command operates only on the single global active context, and the only way to target another is `context select <name>`, which mutates state shared across every shell and project on the machine. That makes per-project workflows impossible. Two projects can't each drive their own stack without stomping on one global pointer.

Contexts are already isolated (ports, data dirs {name}-{version}-{context}, container names all include the context), and the internal package layer (install/startService/stopService/etc.) already takes an explicit context argument. The only thing hard-wired to the global pointer was which context name gets fed in.

## Approach

The PackageManager gained a per-instance `contextOverride`. A new `effectiveContext()` helper returns the override when set; otherwise, the persisted active context. The methods that previously read the active context now read the effective one:

- `InstalledPackages()` filters on the effective context.
- `initTemplate()`, `Install`, `Upgrade`, `Uninstall`, `Logs`, `Info` use the effective context name/network.

The CLI registers the persistent flag and applies it once in `createPackageManager()`, so every command inherits it for free.

## Behavior notes

- Backward compatible: absent the flag, `contextOverride` is empty, and `effectiveContext()` collapses to the active context. No change to existing behavior.
- Validation: an unknown `--context` fails fast before any work runs.
- Guarded commands: `--context` is rejected on context select/create/delete, which manage the persisted active pointer itself. `context env` and `list` honor it.

I also renamed the now-misleading activeContext* locals to context* in methods that operate on the effective (possibly overridden) context, while keeping the active* naming where the active context is genuinely intended.

  ## Testing

- New unit tests: default targeting, override targeting, no-mutation of the active context, and unknown-context error.
- go build, go vet, gofmt, full go test ./..., and golangci-lint all pass.
- Manual CLI checks: flag in help; invalid context fails fast; guard rejects context select; list/context env honor the override; active context unchanged afterward.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a global `--context` (`-c`) flag so any `cardano-up` command can target a named context for a single run without changing the active context. This enables per‑project workflows and parallel stacks on the same machine.

- **New Features**
  - Global per-command context override; does not mutate `active_context.yaml`.
  - Honored by lifecycle/query commands (`up`/`start`, `down`/`stop`, `install`, `upgrade`, `uninstall`, `logs`, `info`, `list`, `context env`); rejected for context management (`context select/create/delete`).
  - Unknown contexts fail fast with a clear error.
  - Backward compatible; without the flag, behavior is unchanged.
  - CLI help and README updated; tests cover targeting and non‑mutation.

- **Refactors**
  - Install debug log now includes the context name when setting the network.

<sup>Written for commit df84d67ae10d1ad7d90fc20e540becec081ce8bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up/pull/536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--context` (`-c` flag to target a different context for a single invocation without changing the persisted active context. Supported with lifecycle and query commands; cannot be combined with context management commands (select/create/delete).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->