### PR TITLE
fix(pkgmgr): forward stdin to hook scripts so nested TTYs work

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/docker/go-connections v0.7.0
 	github.com/hashicorp/go-version v1.9.0
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/sys v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -66,7 +67,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gotest.tools/v3 v3.5.1 // indirect
 )

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -659,9 +659,15 @@ func (p Package) runHookScript(cfg Config, hookScript string) error {
 		return fmt.Errorf("failed to render hook script template: %w", err)
 	}
 	cmd := exec.Command("/bin/sh", "-c", renderedScript)
+	// Wire the hook's stdio straight through to our own. Forwarding stdin is
+	// what lets an interactive child process inherit our controlling terminal:
+	// the cardano-node preInstall hook shells out to the mithril-client wrapper,
+	// which runs "docker run -ti ...". Without a real stdin the nested TTY
+	// allocation breaks, leaving the terminal in a bad state and orphaning the
+	// long-running snapshot download in the background. See issue #239.
+	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	// We won't be reading or writing, so throw away the PTY file
 	err = cmd.Start()
 	if err != nil {
 		return fmt.Errorf("failed to run hook script: %w", err)

--- a/pkgmgr/package_test.go
+++ b/pkgmgr/package_test.go
@@ -15,6 +15,8 @@
 package pkgmgr
 
 import (
+	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -208,5 +210,99 @@ func TestServiceHooks_PreStartAndPreStop(t *testing.T) {
 			string(preStopOutput),
 			"prestop executed\n",
 		)
+	}
+}
+
+// runHookWithStdin runs the given hook script with the provided file as the
+// process stdin, capturing whatever the hook writes to stdout/stderr.
+//
+// runHookScript wires the child's stdio to the os.Std* package vars, so the
+// only way to exercise that behavior is to swap those globals for the duration
+// of the call. That makes these tests inherently non-parallel.
+func runHookWithStdin(
+	t *testing.T,
+	stdin *os.File,
+	script string,
+) (string, error) {
+	t.Helper()
+
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+
+	// Drain the read end concurrently so a hook that produces more output than
+	// the pipe buffer can hold does not deadlock against cmd.Wait().
+	outCh := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, rOut)
+		outCh <- buf.String()
+	}()
+
+	origIn, origOut, origErr := os.Stdin, os.Stdout, os.Stderr
+	os.Stdin, os.Stdout, os.Stderr = stdin, wOut, wOut
+	defer func() {
+		os.Stdin, os.Stdout, os.Stderr = origIn, origOut, origErr
+	}()
+
+	cfg := Config{Template: NewTemplate(nil)}
+	runErr := Package{}.runHookScript(cfg, script)
+
+	// Close our copy of the write end so the drain goroutine sees EOF.
+	_ = wOut.Close()
+	out := <-outCh
+	_ = rOut.Close()
+
+	return out, runErr
+}
+
+func TestRunHookScriptForwardsStdin(t *testing.T) {
+	// A regular file gives the hook a natural EOF, so `cat` reads it and exits.
+	inPath := filepath.Join(t.TempDir(), "stdin")
+	want := "hello from stdin\n"
+	if err := os.WriteFile(inPath, []byte(want), 0o600); err != nil {
+		t.Fatalf("failed to write stdin file: %v", err)
+	}
+	f, err := os.Open(inPath)
+	if err != nil {
+		t.Fatalf("failed to open stdin file: %v", err)
+	}
+	defer f.Close()
+
+	got, err := runHookWithStdin(t, f, "cat")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("stdin was not forwarded to the hook: got %q, want %q", got, want)
+	}
+}
+
+func TestRunHookScriptSuccess(t *testing.T) {
+	f, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("failed to open %s: %v", os.DevNull, err)
+	}
+	defer f.Close()
+
+	if _, err := runHookWithStdin(t, f, "exit 0"); err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+}
+
+func TestRunHookScriptError(t *testing.T) {
+	f, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("failed to open %s: %v", os.DevNull, err)
+	}
+	defer f.Close()
+
+	_, err = runHookWithStdin(t, f, "exit 7")
+	if err == nil {
+		t.Fatal("expected a non-zero exit to return an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "exited with error") {
+		t.Fatalf("unexpected error message: %v", err)
 	}
 }

--- a/pkgmgr/package_tty_linux_test.go
+++ b/pkgmgr/package_tty_linux_test.go
@@ -1,0 +1,92 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkgmgr
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// openPTY allocates a pseudo-terminal pair and returns its master and slave
+// ends. The slave behaves like a real terminal, which is what we need to prove
+// that runHookScript forwards a TTY stdin through to the hook's child process.
+//
+// This uses the Linux /dev/ptmx mechanism directly to avoid pulling in a PTY
+// dependency just for tests. If a PTY cannot be allocated (e.g. a restricted
+// sandbox without /dev/pts) the test is skipped rather than failed.
+func openPTY(t *testing.T) (master, slave *os.File) {
+	t.Helper()
+
+	fd, err := unix.Open("/dev/ptmx", unix.O_RDWR|unix.O_NOCTTY, 0)
+	if err != nil {
+		t.Skipf("cannot open /dev/ptmx, skipping TTY test: %v", err)
+	}
+	master = os.NewFile(uintptr(fd), "ptmx")
+
+	// Unlock the slave side before opening it.
+	if err := unix.IoctlSetPointerInt(fd, unix.TIOCSPTLCK, 0); err != nil {
+		_ = master.Close()
+		t.Skipf("cannot unlock pts (TIOCSPTLCK): %v", err)
+	}
+	ptn, err := unix.IoctlGetInt(fd, unix.TIOCGPTN)
+	if err != nil {
+		_ = master.Close()
+		t.Skipf("cannot get pts number (TIOCGPTN): %v", err)
+	}
+
+	slavePath := fmt.Sprintf("/dev/pts/%d", ptn)
+	slave, err = os.OpenFile(slavePath, os.O_RDWR|unix.O_NOCTTY, 0)
+	if err != nil {
+		_ = master.Close()
+		t.Skipf("cannot open %s: %v", slavePath, err)
+	}
+	return master, slave
+}
+
+// TestRunHookScriptStdinTTY is the regression guard for issue #239: when our
+// own stdin is a terminal, the hook's child process must also see its stdin as
+// a terminal (so e.g. "docker run -ti" can allocate a TTY). The negative
+// control confirms the check is meaningful — a non-terminal stdin must not look
+// like a TTY.
+func TestRunHookScriptStdinTTY(t *testing.T) {
+	t.Run("tty stdin is a tty to the child", func(t *testing.T) {
+		master, slave := openPTY(t)
+		defer master.Close()
+		defer slave.Close()
+
+		// `test -t 0` exits 0 only if fd 0 is a terminal.
+		if _, err := runHookWithStdin(t, slave, "test -t 0"); err != nil {
+			t.Fatalf(
+				"expected the hook's child to see a TTY stdin, got error: %v",
+				err,
+			)
+		}
+	})
+
+	t.Run("non-tty stdin is not a tty to the child", func(t *testing.T) {
+		f, err := os.Open(os.DevNull)
+		if err != nil {
+			t.Fatalf("failed to open %s: %v", os.DevNull, err)
+		}
+		defer f.Close()
+
+		if _, err := runHookWithStdin(t, f, "test -t 0"); err == nil {
+			t.Fatal("expected non-TTY stdin to fail `test -t 0`, got nil error")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes the fragile Mithril snapshot download in the cardano-node package (#239).

`runHookScript` left `cmd.Stdin` unset, so hook scripts ran with stdin connected to `/dev/null` and no controlling terminal. The cardano-node `preInstall` hook shells out to the mithril-client wrapper, which runs `docker run -ti ...`. Without a real stdin the nested TTY allocation breaks — leaving the terminal in a bad state ("losing access to the terminal") and orphaning the long-running snapshot download in the background. Running the same command manually works precisely because a real TTY is present.

This wires `cmd.Stdin = os.Stdin` so the hook and its child processes inherit our controlling terminal, restoring the behavior that the PTY removal in `6a4df21` (#305) regressed. Passing stdin through is safe in non-interactive contexts too — it just mirrors the parent's stdin rather than the old `/dev/null` — so no TTY-detection branch is needed.

## Tests

- `TestRunHookScriptForwardsStdin` — a `cat` hook round-trips stdin (the core regression guard).
- `TestRunHookScriptSuccess` / `TestRunHookScriptError` — exit code is surfaced correctly.
- `TestRunHookScriptStdinTTY` (Linux-only) — allocates a real PTY via `/dev/ptmx` and asserts that a TTY stdin is visible to the hook's child (`test -t 0`), with a non-TTY `/dev/null` control. Uses `golang.org/x/sys/unix` (already in the dependency tree) instead of re-adding a pty dependency; skips gracefully where no PTY is available.

Verified the tests are genuine regression guards: with the fix removed, the stdin-forwarding and positive TTY assertions fail; with it restored, all pass. `go test -race ./pkgmgr/`, `golangci-lint`, `nilaway`, and `go vet` are clean.

## Notes

- `go.mod`: `golang.org/x/sys` moved from indirect to direct (same version, no new modules).
- Out of scope (deferred): hardening process lifecycle (process group + signal forwarding) so cancelling cardano-up tears down an in-flight download instead of orphaning it. Worth a follow-up.
- The mithril-client wrapper's `docker run -ti` lives in the separate `cardano-up-packages` repo and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forwards stdin to hook scripts in `pkgmgr` so nested TTYs work, fixing the fragile Mithril snapshot download in the `cardano-node` preInstall hook. Restores proper terminal behavior and avoids orphaned background downloads.

- **Bug Fixes**
  - Hook scripts now inherit stdin (`cmd.Stdin = os.Stdin`), allowing the `mithril-client` wrapper’s `docker run -ti` to allocate a TTY correctly.
  - Added regression tests for stdin forwarding, exit codes, and a Linux-only PTY check that verifies TTY visibility.

- **Dependencies**
  - Promoted `golang.org/x/sys` to a direct dependency (version unchanged).

<sup>Written for commit 6d5929fa77ab4e6627f5bd98ac0f5c4d9ca33199. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up/pull/538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hook scripts now properly forward standard input to child processes, enabling interactive and TTY-dependent operations.

* **Tests**
  * Added comprehensive tests validating stdin forwarding and TTY handling in hook script execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->