### PR TITLE
feat(pkgmgr):  Create postStart hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,9 @@ The package manifest format is a YAML file with the following fields:
 | `description` | | Package description |
 | `preInstallScript` | | Arbitrary command that will be run before the package is installed |
 | `postInstallScript` | | Arbitrary command that will be run after the package is installed |
+| `preStartScript` | | Arbitrary command that will be run before package services are started |
+| `postStartScript` | | Arbitrary command that will be run after package services are started |
+| `preStopScript` | | Arbitrary command that will be run before package services are stopped |
 | `preUninstallScript` | | Arbitrary command that will be run before the package is uninstalled |
 | `postUninstallScript` | | Arbitrary command that will be run after the package is uninstalled |
 | `installSteps` | | Steps to install package |

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -48,6 +48,7 @@ type Package struct {
 	PreInstallScript    string               `yaml:"preInstallScript,omitempty"`
 	PostInstallScript   string               `yaml:"postInstallScript,omitempty"`
 	PreStartScript      string               `yaml:"preStartScript,omitempty"`
+	PostStartScript     string               `yaml:"postStartScript,omitempty"`
 	PreStopScript       string               `yaml:"preStopScript,omitempty"`
 	PreUninstallScript  string               `yaml:"preUninstallScript,omitempty"`
 	PostUninstallScript string               `yaml:"postUninstallScript,omitempty"`
@@ -573,6 +574,13 @@ func (p Package) startService(cfg Config, context string) error {
 	if len(startErrors) > 0 {
 		slog.Error(strings.Join(startErrors, "\n"))
 		return ErrOperationFailed
+	}
+
+	// Run post-start script
+	if p.PostStartScript != "" {
+		if err := p.runHookScript(cfg, p.PostStartScript); err != nil {
+			return fmt.Errorf("post-start hook failed: %w", err)
+		}
 	}
 
 	return nil

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -577,6 +577,9 @@ func (p Package) startService(cfg Config, context string) error {
 				)
 				continue
 			}
+			if wasRunning {
+				continue
+			}
 			// Start the Docker container if it's not running
 			slog.Info(
 				"Starting Docker container " + containerName,
@@ -592,9 +595,7 @@ func (p Package) startService(cfg Config, context string) error {
 				)
 				continue
 			}
-			if !wasRunning {
-				startedServices = append(startedServices, dockerService)
-			}
+			startedServices = append(startedServices, dockerService)
 		}
 	}
 

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -539,7 +539,7 @@ func (p Package) startService(cfg Config, context string) error {
 		}
 	}
 	var startErrors []string
-	var startedServices []serviceLifecycle
+	startedServices := make([]serviceLifecycle, 0)
 	for _, step := range p.InstallSteps {
 		if step.Docker != nil {
 			if step.Docker.PullOnly {
@@ -616,6 +616,9 @@ func (p Package) startService(cfg Config, context string) error {
 }
 
 func (p Package) rollbackStartedServices(startedServices []serviceLifecycle) {
+	if len(startedServices) == 0 {
+		return
+	}
 	for idx := len(startedServices) - 1; idx >= 0; idx-- {
 		if err := startedServices[idx].Stop(); err != nil {
 			slog.Warn(

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -70,6 +70,16 @@ type PackageOutput struct {
 	Value       string `yaml:"value"`
 }
 
+type serviceLifecycle interface {
+	Running() (bool, error)
+	Start() error
+	Stop() error
+}
+
+var newServiceFromContainerName = func(containerName string, logger *slog.Logger) (serviceLifecycle, error) {
+	return NewDockerServiceFromContainerName(containerName, logger)
+}
+
 func NewPackageFromFile(path string) (Package, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -529,6 +539,7 @@ func (p Package) startService(cfg Config, context string) error {
 		}
 	}
 	var startErrors []string
+	var startedServices []serviceLifecycle
 	for _, step := range p.InstallSteps {
 		if step.Docker != nil {
 			if step.Docker.PullOnly {
@@ -539,7 +550,7 @@ func (p Package) startService(cfg Config, context string) error {
 				pkgName,
 				step.Docker.ContainerName,
 			)
-			dockerService, err := NewDockerServiceFromContainerName(
+			dockerService, err := newServiceFromContainerName(
 				containerName,
 				cfg.Logger,
 			)
@@ -548,6 +559,18 @@ func (p Package) startService(cfg Config, context string) error {
 					startErrors,
 					fmt.Sprintf(
 						"error initializing Docker service for container %s: %v",
+						containerName,
+						err,
+					),
+				)
+				continue
+			}
+			wasRunning, err := dockerService.Running()
+			if err != nil {
+				startErrors = append(
+					startErrors,
+					fmt.Sprintf(
+						"error checking Docker container status for %s: %v",
 						containerName,
 						err,
 					),
@@ -567,11 +590,16 @@ func (p Package) startService(cfg Config, context string) error {
 						err,
 					),
 				)
+				continue
+			}
+			if !wasRunning {
+				startedServices = append(startedServices, dockerService)
 			}
 		}
 	}
 
 	if len(startErrors) > 0 {
+		p.rollbackStartedServices(startedServices)
 		slog.Error(strings.Join(startErrors, "\n"))
 		return ErrOperationFailed
 	}
@@ -579,11 +607,25 @@ func (p Package) startService(cfg Config, context string) error {
 	// Run post-start script
 	if p.PostStartScript != "" {
 		if err := p.runHookScript(cfg, p.PostStartScript); err != nil {
+			p.rollbackStartedServices(startedServices)
 			return fmt.Errorf("post-start hook failed: %w", err)
 		}
 	}
 
 	return nil
+}
+
+func (p Package) rollbackStartedServices(startedServices []serviceLifecycle) {
+	for idx := len(startedServices) - 1; idx >= 0; idx-- {
+		if err := startedServices[idx].Stop(); err != nil {
+			slog.Warn(
+				fmt.Sprintf(
+					"failed to roll back started service after start failure: %v",
+					err,
+				),
+			)
+		}
+	}
 }
 
 func (p Package) stopService(cfg Config, context string) error {

--- a/pkgmgr/package_test.go
+++ b/pkgmgr/package_test.go
@@ -138,21 +138,27 @@ func TestOSAndARCH(t *testing.T) {
 	}
 }
 
-func TestServiceHooks_PreStartAndPreStop(t *testing.T) {
+func TestServiceHooks_PreStartPostStartAndPreStop(t *testing.T) {
 	tmpDir := t.TempDir()
+	hookLog := filepath.Join(tmpDir, "hooks.log")
 
 	// Create preStart script
-	preStartLog := filepath.Join(tmpDir, "prestart.log")
 	preStartScript := filepath.Join(tmpDir, "prestart.sh")
-	preStartContent := "#!/bin/sh\necho 'prestart executed' > " + preStartLog
+	preStartContent := "#!/bin/sh\necho 'prestart executed' >> " + hookLog
 	if err := os.WriteFile(preStartScript, []byte(preStartContent), 0755); err != nil {
 		t.Fatalf("failed to write preStart script: %v", err)
 	}
 
+	// Create postStart script
+	postStartScript := filepath.Join(tmpDir, "poststart.sh")
+	postStartContent := "#!/bin/sh\necho 'poststart executed' >> " + hookLog
+	if err := os.WriteFile(postStartScript, []byte(postStartContent), 0755); err != nil {
+		t.Fatalf("failed to write postStart script: %v", err)
+	}
+
 	// Create preStop script
-	preStopLog := filepath.Join(tmpDir, "prestop.log")
 	preStopScript := filepath.Join(tmpDir, "prestop.sh")
-	preStopContent := "#!/bin/sh\necho 'prestop executed' > " + preStopLog
+	preStopContent := "#!/bin/sh\necho 'prestop executed' >> " + hookLog
 	if err := os.WriteFile(preStopScript, []byte(preStopContent), 0755); err != nil {
 		t.Fatalf("failed to write preStop script: %v", err)
 	}
@@ -169,11 +175,12 @@ func TestServiceHooks_PreStartAndPreStop(t *testing.T) {
 	}
 	// Define a test package
 	pkg := Package{
-		Name:           "mypkg",
-		Version:        "1.0.0",
-		PreStartScript: preStartScript,
-		PreStopScript:  preStopScript,
-		InstallSteps:   []PackageInstallStep{},
+		Name:            "mypkg",
+		Version:         "1.0.0",
+		PreStartScript:  preStartScript,
+		PostStartScript: postStartScript,
+		PreStopScript:   preStopScript,
+		InstallSteps:    []PackageInstallStep{},
 	}
 
 	// Execute startService and expect preStartScript to run
@@ -181,16 +188,16 @@ func TestServiceHooks_PreStartAndPreStop(t *testing.T) {
 		t.Fatalf("startService failed: %v", err)
 	}
 
-	// Validate preStart script output
-	preStartOutput, err := os.ReadFile(preStartLog)
+	// Validate start hook output
+	startOutput, err := os.ReadFile(hookLog)
 	if err != nil {
-		t.Fatalf("preStart log file not found: %v", err)
+		t.Fatalf("hook log file not found: %v", err)
 	}
-	if string(preStartOutput) != "prestart executed\n" {
+	if string(startOutput) != "prestart executed\npoststart executed\n" {
 		t.Errorf(
-			"unexpected preStart output: got %q, want %q",
-			string(preStartOutput),
-			"prestart executed\n",
+			"unexpected start hook output: got %q, want %q",
+			string(startOutput),
+			"prestart executed\npoststart executed\n",
 		)
 	}
 
@@ -199,16 +206,16 @@ func TestServiceHooks_PreStartAndPreStop(t *testing.T) {
 		t.Fatalf("stopService failed: %v", err)
 	}
 
-	// Validate preStop script output
-	preStopOutput, err := os.ReadFile(preStopLog)
+	// Validate all hook output
+	hookOutput, err := os.ReadFile(hookLog)
 	if err != nil {
-		t.Fatalf("preStop log file not found: %v", err)
+		t.Fatalf("hook log file not found: %v", err)
 	}
-	if string(preStopOutput) != "prestop executed\n" {
+	if string(hookOutput) != "prestart executed\npoststart executed\nprestop executed\n" {
 		t.Errorf(
-			"unexpected preStop output: got %q, want %q",
-			string(preStopOutput),
-			"prestop executed\n",
+			"unexpected hook output: got %q, want %q",
+			string(hookOutput),
+			"prestart executed\npoststart executed\nprestop executed\n",
 		)
 	}
 }

--- a/pkgmgr/package_test.go
+++ b/pkgmgr/package_test.go
@@ -17,6 +17,7 @@ package pkgmgr
 import (
 	"bytes"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -27,6 +28,28 @@ import (
 
 	"gopkg.in/yaml.v3"
 )
+
+type fakeServiceLifecycle struct {
+	running bool
+	started bool
+	stopped bool
+}
+
+func (f *fakeServiceLifecycle) Running() (bool, error) {
+	return f.running, nil
+}
+
+func (f *fakeServiceLifecycle) Start() error {
+	f.started = true
+	f.running = true
+	return nil
+}
+
+func (f *fakeServiceLifecycle) Stop() error {
+	f.stopped = true
+	f.running = false
+	return nil
+}
 
 var packageTestDefs = []struct {
 	yaml       string
@@ -217,6 +240,67 @@ func TestServiceHooks_PreStartPostStartAndPreStop(t *testing.T) {
 			string(hookOutput),
 			"prestart executed\npoststart executed\nprestop executed\n",
 		)
+	}
+}
+
+func TestStartService_RollsBackStartedServicesOnPostStartFailure(t *testing.T) {
+	origNewServiceFromContainerName := newServiceFromContainerName
+	t.Cleanup(func() {
+		newServiceFromContainerName = origNewServiceFromContainerName
+	})
+
+	startedSvc := &fakeServiceLifecycle{}
+	alreadyRunningSvc := &fakeServiceLifecycle{running: true}
+	services := map[string]*fakeServiceLifecycle{
+		"mypkg-1.0.0-testctx-started": startedSvc,
+		"mypkg-1.0.0-testctx-running": alreadyRunningSvc,
+	}
+	newServiceFromContainerName = func(containerName string, logger *slog.Logger) (serviceLifecycle, error) {
+		return services[containerName], nil
+	}
+
+	cfg := Config{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Template: &Template{
+			tmpl:     template.New("test"),
+			baseVars: make(map[string]any),
+		},
+	}
+	pkg := Package{
+		Name:            "mypkg",
+		Version:         "1.0.0",
+		PostStartScript: "exit 1",
+		InstallSteps: []PackageInstallStep{
+			{
+				Docker: &PackageInstallStepDocker{
+					ContainerName: "started",
+					Image:         "alpine:3.20",
+				},
+			},
+			{
+				Docker: &PackageInstallStepDocker{
+					ContainerName: "running",
+					Image:         "alpine:3.20",
+				},
+			},
+		},
+	}
+
+	err := pkg.startService(cfg, "testctx")
+	if err == nil {
+		t.Fatal("expected post-start hook failure")
+	}
+	if !strings.Contains(err.Error(), "post-start hook failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !startedSvc.started {
+		t.Fatal("expected stopped service to be started")
+	}
+	if !startedSvc.stopped {
+		t.Fatal("expected newly-started service to be stopped during rollback")
+	}
+	if alreadyRunningSvc.stopped {
+		t.Fatal("expected already-running service to be left running")
 	}
 }
 


### PR DESCRIPTION
1. Added postStartScript support so packages can run a hook after their services start successfully.
2. Added `postStartScript` to the package manifest schema.
3. Made changes to `startService` to run `postStartScript` after all Docker services start successfully.
4. Kept failure behavior conservative: if service startup fails, the post-start hook is skipped.
5. Added test coverage for service hook execution order.
6. Documented `postStartScript` in the README package manifest table.

Closes #398 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a post-start hook so packages can run a `postStartScript` after services are up, with safe rollback. Also skips logging/starting for already-running containers to avoid misleading logs. Implements Linear #398.

- **New Features**
  - Added `postStartScript` to the package manifest schema.
  - `startService` starts Docker services, skips containers already running, then runs `postStartScript`; tracks services started in this call and rolls back only those on start or post-start errors.
  - Tests cover hook order and rollback; README documents `preStartScript`, `postStartScript`, and `preStopScript`.

<sup>Written for commit 984d449b4ca358b9c16233eefbfeb2e7c4e3e508. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up/pull/547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new `postStartScript` package manifest field.
  * Service hooks can now run before start, after a successful start, and before stop.

* **Documentation**
  * Updated the package manifest reference with the new hook fields and their descriptions.

* **Tests**
  * Expanded coverage to verify hook execution order across start and stop flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->