### PR TITLE
feat(pkgmgr): Support installing single binaries from ZIP and compressed tarballs

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,9 +359,9 @@ installSteps:
 | Field | Required | Description |
 | --- | :---: | --- |
 | `filename` | x | Name of destination file. This will be created within the package's data directory |
-| `source` | | Path to source file. This should be a relative path within the package manifest directory. This takes precedence over `content` and `url` if more than one is provided |
-| `content` | | Inline content for destination file |
-| `url` | | URL to fetch destination file content from. Supports templating (e.g. `{{ .System.OS }}` and `{{ .System.ARCH }}`) |
+| `source` | | Path to source file. This should be a relative path within the package manifest directory. Used only if `content` is not provided |
+| `content` | | Inline content for destination file. Takes precedence over `source` and `url` if more than one is provided |
+| `url` | | URL to fetch destination file content from. Used only if `content` and `source` are not provided. Supports templating (e.g. `{{ .System.OS }}` and `{{ .System.ARCH }}`) |
 | `mode` | | Octal file mode for destination file |
 | `binary` | | Whether this file is an executable file for the package (expects bool, defaults to `false`) |
 | `archive` | | Archive format that `source` or `url` content should be extracted from. One of `zip`, `tar.gz`, or `tgz` |

--- a/README.md
+++ b/README.md
@@ -343,13 +343,29 @@ installSteps:
       source: my-source-file
 ```
 
+A file can also be downloaded from a URL and, optionally, extracted from a ZIP or tar.gz archive. This is
+useful for installing a binary directly from a project's release artifacts.
+
+```yaml
+installSteps:
+  - file:
+      filename: my-binary
+      binary: true
+      url: https://example.com/releases/my-project-{{ .System.OS }}-{{ .System.ARCH }}.tar.gz
+      archive: tar.gz
+      archivePath: my-project/bin/my-binary
+```
+
 | Field | Required | Description |
 | --- | :---: | --- |
 | `filename` | x | Name of destination file. This will be created within the package's data directory |
-| `source` | | Path to source file. This should be a relative path within the package manifest directory. This takes precedence over `content` if both are provided |
+| `source` | | Path to source file. This should be a relative path within the package manifest directory. This takes precedence over `content` and `url` if more than one is provided |
 | `content` | | Inline content for destination file |
+| `url` | | URL to fetch destination file content from. Supports templating (e.g. `{{ .System.OS }}` and `{{ .System.ARCH }}`) |
 | `mode` | | Octal file mode for destination file |
 | `binary` | | Whether this file is an executable file for the package (expects bool, defaults to `false`) |
+| `archive` | | Archive format that `source` or `url` content should be extracted from. One of `zip`, `tar.gz`, or `tgz` |
+| `archivePath` | | Path of the file within the archive to extract as the destination file content. Required if `archive` is set. Supports templating |
 
 ##### `dependencies`
 

--- a/pkgmgr/archive.go
+++ b/pkgmgr/archive.go
@@ -1,0 +1,113 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkgmgr
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+)
+
+// Supported values for the file install step's archive field
+const (
+	archiveTypeZip   = "zip"
+	archiveTypeTarGz = "tar.gz"
+	archiveTypeTgz   = "tgz"
+)
+
+// validArchiveType returns whether archiveType is a supported archive type
+// for the file install step
+func validArchiveType(archiveType string) bool {
+	switch strings.ToLower(archiveType) {
+	case archiveTypeZip, archiveTypeTarGz, archiveTypeTgz:
+		return true
+	default:
+		return false
+	}
+}
+
+// extractArchiveFile returns the content of the file at archivePath within
+// the archive represented by data. The archive is expected to be in the
+// format specified by archiveType (zip, tar.gz, or tgz)
+func extractArchiveFile(
+	archiveType string,
+	archivePath string,
+	data []byte,
+) ([]byte, error) {
+	switch strings.ToLower(archiveType) {
+	case archiveTypeZip:
+		return extractZipFile(archivePath, data)
+	case archiveTypeTarGz, archiveTypeTgz:
+		return extractTarGzFile(archivePath, data)
+	default:
+		return nil, fmt.Errorf("unsupported archive type %q", archiveType)
+	}
+}
+
+func extractZipFile(archivePath string, data []byte) ([]byte, error) {
+	zipReader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read zip archive: %w", err)
+	}
+	cleanPath := filepath.Clean(archivePath)
+	for _, zipFile := range zipReader.File {
+		if zipFile.FileInfo().IsDir() {
+			continue
+		}
+		if filepath.Clean(zipFile.Name) != cleanPath {
+			continue
+		}
+		zf, err := zipFile.Open()
+		if err != nil {
+			return nil, err
+		}
+		defer zf.Close()
+		return io.ReadAll(zf)
+	}
+	return nil, fmt.Errorf("file %q not found in zip archive", archivePath)
+}
+
+func extractTarGzFile(archivePath string, data []byte) ([]byte, error) {
+	gzipReader, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read gzip data: %w", err)
+	}
+	defer gzipReader.Close()
+	cleanPath := filepath.Clean(archivePath)
+	tarReader := tar.NewReader(gzipReader)
+	for {
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to read tar archive: %w", err)
+		}
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+		if filepath.Clean(header.Name) != cleanPath {
+			continue
+		}
+		return io.ReadAll(tarReader)
+	}
+	return nil, fmt.Errorf("file %q not found in tar.gz archive", archivePath)
+}

--- a/pkgmgr/archive.go
+++ b/pkgmgr/archive.go
@@ -180,6 +180,12 @@ func drainTarGzArchive(
 			return fmt.Errorf("failed to read tar archive: %w", err)
 		}
 		if _, err := io.Copy(io.Discard, tarReader); err != nil {
+			if limitedGzipReader.N == 0 {
+				return fmt.Errorf(
+					"archive exceeds maximum decompressed size of %d bytes",
+					maxDecompressedSize,
+				)
+			}
 			return fmt.Errorf("failed to drain tar archive: %w", err)
 		}
 		if limitedGzipReader.N == 0 {

--- a/pkgmgr/archive.go
+++ b/pkgmgr/archive.go
@@ -28,9 +28,10 @@ import (
 
 // Supported values for the file install step's archive field
 const (
-	archiveTypeZip   = "zip"
-	archiveTypeTarGz = "tar.gz"
-	archiveTypeTgz   = "tgz"
+	archiveTypeZip      = "zip"
+	archiveTypeTarGz    = "tar.gz"
+	archiveTypeTgz      = "tgz"
+	maxArchiveEntrySize = int64(512 * 1024 * 1024) // 512 MiB
 )
 
 // validArchiveType returns whether archiveType is a supported archive type
@@ -75,12 +76,19 @@ func extractZipFile(archivePath string, data []byte) ([]byte, error) {
 		if filepath.Clean(zipFile.Name) != cleanPath {
 			continue
 		}
+		if zipFile.UncompressedSize64 > uint64(maxArchiveEntrySize) {
+			return nil, fmt.Errorf(
+				"file %q exceeds maximum allowed size of %d bytes",
+				archivePath,
+				maxArchiveEntrySize,
+			)
+		}
 		zf, err := zipFile.Open()
 		if err != nil {
 			return nil, err
 		}
 		defer zf.Close()
-		return io.ReadAll(zf)
+		return readArchiveEntry(zf, archivePath, maxArchiveEntrySize)
 	}
 	return nil, fmt.Errorf("file %q not found in zip archive", archivePath)
 }
@@ -107,7 +115,67 @@ func extractTarGzFile(archivePath string, data []byte) ([]byte, error) {
 		if filepath.Clean(header.Name) != cleanPath {
 			continue
 		}
-		return io.ReadAll(tarReader)
+		if header.Size > maxArchiveEntrySize {
+			return nil, fmt.Errorf(
+				"file %q exceeds maximum allowed size of %d bytes",
+				archivePath,
+				maxArchiveEntrySize,
+			)
+		}
+		content, err := readArchiveEntry(
+			tarReader,
+			archivePath,
+			maxArchiveEntrySize,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if err := drainTarGzArchive(tarReader, gzipReader); err != nil {
+			return nil, err
+		}
+		return content, nil
 	}
 	return nil, fmt.Errorf("file %q not found in tar.gz archive", archivePath)
+}
+
+// drainTarGzArchive consumes the rest of the tar and gzip streams so gzip can
+// verify its checksum before the selected file is installed.
+func drainTarGzArchive(tarReader *tar.Reader, gzipReader *gzip.Reader) error {
+	for {
+		_, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read tar archive: %w", err)
+		}
+		if _, err := io.Copy(io.Discard, tarReader); err != nil {
+			return fmt.Errorf("failed to drain tar archive: %w", err)
+		}
+	}
+	if _, err := io.Copy(io.Discard, gzipReader); err != nil {
+		return fmt.Errorf("failed to verify gzip data: %w", err)
+	}
+	return nil
+}
+
+// readArchiveEntry limits extraction even if an archive reports an incorrect
+// uncompressed size in its metadata.
+func readArchiveEntry(
+	reader io.Reader,
+	archivePath string,
+	maxSize int64,
+) ([]byte, error) {
+	content, err := io.ReadAll(io.LimitReader(reader, maxSize+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(content)) > maxSize {
+		return nil, fmt.Errorf(
+			"file %q exceeds maximum allowed size of %d bytes",
+			archivePath,
+			maxSize,
+		)
+	}
+	return content, nil
 }

--- a/pkgmgr/archive.go
+++ b/pkgmgr/archive.go
@@ -76,7 +76,10 @@ func extractZipFile(archivePath string, data []byte) ([]byte, error) {
 	}
 	cleanPath := filepath.Clean(archivePath)
 	for _, zipFile := range zipReader.File {
-		if zipFile.FileInfo().IsDir() {
+		// Skip directories, symlinks, and other non-regular entries. A
+		// symlink's "content" is just its target path string, which would
+		// otherwise be silently written out as the file/binary content.
+		if !zipFile.Mode().IsRegular() {
 			continue
 		}
 		if filepath.Clean(zipFile.Name) != cleanPath {

--- a/pkgmgr/archive.go
+++ b/pkgmgr/archive.go
@@ -94,13 +94,29 @@ func extractZipFile(archivePath string, data []byte) ([]byte, error) {
 }
 
 func extractTarGzFile(archivePath string, data []byte) ([]byte, error) {
+	return extractTarGzFileWithLimit(
+		archivePath,
+		data,
+		maxArchiveEntrySize,
+	)
+}
+
+func extractTarGzFileWithLimit(
+	archivePath string,
+	data []byte,
+	maxDecompressedSize int64,
+) ([]byte, error) {
 	gzipReader, err := gzip.NewReader(bytes.NewReader(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read gzip data: %w", err)
 	}
 	defer gzipReader.Close()
 	cleanPath := filepath.Clean(archivePath)
-	tarReader := tar.NewReader(gzipReader)
+	limitedGzipReader := &io.LimitedReader{
+		R: gzipReader,
+		N: maxDecompressedSize + 1,
+	}
+	tarReader := tar.NewReader(limitedGzipReader)
 	for {
 		header, err := tarReader.Next()
 		if errors.Is(err, io.EOF) {
@@ -130,7 +146,11 @@ func extractTarGzFile(archivePath string, data []byte) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		if err := drainTarGzArchive(tarReader, gzipReader); err != nil {
+		if err := drainTarGzArchive(
+			tarReader,
+			limitedGzipReader,
+			maxDecompressedSize,
+		); err != nil {
 			return nil, err
 		}
 		return content, nil
@@ -140,21 +160,43 @@ func extractTarGzFile(archivePath string, data []byte) ([]byte, error) {
 
 // drainTarGzArchive consumes the rest of the tar and gzip streams so gzip can
 // verify its checksum before the selected file is installed.
-func drainTarGzArchive(tarReader *tar.Reader, gzipReader *gzip.Reader) error {
+func drainTarGzArchive(
+	tarReader *tar.Reader,
+	limitedGzipReader *io.LimitedReader,
+	maxDecompressedSize int64,
+) error {
 	for {
 		_, err := tarReader.Next()
 		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
+			if limitedGzipReader.N == 0 {
+				return fmt.Errorf(
+					"archive exceeds maximum decompressed size of %d bytes",
+					maxDecompressedSize,
+				)
+			}
 			return fmt.Errorf("failed to read tar archive: %w", err)
 		}
 		if _, err := io.Copy(io.Discard, tarReader); err != nil {
 			return fmt.Errorf("failed to drain tar archive: %w", err)
 		}
+		if limitedGzipReader.N == 0 {
+			return fmt.Errorf(
+				"archive exceeds maximum decompressed size of %d bytes",
+				maxDecompressedSize,
+			)
+		}
 	}
-	if _, err := io.Copy(io.Discard, gzipReader); err != nil {
+	if _, err := io.Copy(io.Discard, limitedGzipReader); err != nil {
 		return fmt.Errorf("failed to verify gzip data: %w", err)
+	}
+	if limitedGzipReader.N == 0 {
+		return fmt.Errorf(
+			"archive exceeds maximum decompressed size of %d bytes",
+			maxDecompressedSize,
+		)
 	}
 	return nil
 }

--- a/pkgmgr/archive.go
+++ b/pkgmgr/archive.go
@@ -34,6 +34,12 @@ const (
 	maxArchiveEntrySize = int64(512 * 1024 * 1024) // 512 MiB
 )
 
+// maxDownloadSize bounds how much of a url-sourced file install step is
+// buffered into memory, so an oversized or malicious response can't exhaust
+// process memory before archive extraction limits even apply. It's a var
+// rather than a const so tests can lower it without downloading 512MiB+.
+var maxDownloadSize = maxArchiveEntrySize
+
 // validArchiveType returns whether archiveType is a supported archive type
 // for the file install step
 func validArchiveType(archiveType string) bool {

--- a/pkgmgr/archive_test.go
+++ b/pkgmgr/archive_test.go
@@ -19,6 +19,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"compress/gzip"
+	"io/fs"
 	"sort"
 	"strings"
 	"testing"
@@ -132,6 +133,32 @@ func TestExtractZipFileSkipsDirs(t *testing.T) {
 
 	if _, err := extractZipFile("bin", buf.Bytes()); err == nil {
 		t.Fatal("expected error when requested path is a directory, got nil")
+	}
+}
+
+// TestExtractZipFileSkipsSymlinks checks that a ZIP symlink entry is ignored
+// instead of its link-target string being returned as the file content.
+func TestExtractZipFileSkipsSymlinks(t *testing.T) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	hdr := &zip.FileHeader{
+		Name:   "bin/mybinary",
+		Method: zip.Store,
+	}
+	hdr.SetMode(fs.ModeSymlink | 0o777)
+	fw, err := zw.CreateHeader(hdr)
+	if err != nil {
+		t.Fatalf("unexpected error creating zip symlink entry: %s", err)
+	}
+	if _, err := fw.Write([]byte("/some/other/target")); err != nil {
+		t.Fatalf("unexpected error writing zip symlink entry: %s", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("unexpected error closing zip writer: %s", err)
+	}
+
+	if _, err := extractZipFile("bin/mybinary", buf.Bytes()); err == nil {
+		t.Fatal("expected error when requested path is a symlink, got nil")
 	}
 }
 

--- a/pkgmgr/archive_test.go
+++ b/pkgmgr/archive_test.go
@@ -19,6 +19,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"compress/gzip"
+	"strings"
 	"testing"
 )
 
@@ -28,6 +29,9 @@ func buildTestZip(t *testing.T, entries map[string]string) []byte {
 	t.Helper()
 	var buf bytes.Buffer
 	zw := zip.NewWriter(&buf)
+	if err := zw.SetComment("{{archive bytes must remain raw"); err != nil {
+		t.Fatalf("unexpected error setting zip comment: %s", err)
+	}
 	for name, content := range entries {
 		fw, err := zw.Create(name)
 		if err != nil {
@@ -47,6 +51,7 @@ func buildTestTarGz(t *testing.T, entries map[string]string) []byte {
 	t.Helper()
 	var buf bytes.Buffer
 	gzw := gzip.NewWriter(&buf)
+	gzw.Comment = "{{archive bytes must remain raw"
 	tw := tar.NewWriter(gzw)
 	for name, content := range entries {
 		hdr := &tar.Header{
@@ -153,6 +158,19 @@ func TestExtractTarGzFileNotFound(t *testing.T) {
 	}
 }
 
+// TestExtractTarGzFileCorruptChecksum checks that extraction fails when the
+// selected entry is readable but the gzip checksum is invalid.
+func TestExtractTarGzFileCorruptChecksum(t *testing.T) {
+	data := buildTestTarGz(t, map[string]string{
+		"bin/mybinary": testArchiveFileContent,
+	})
+	data[len(data)-8] ^= 0xff
+
+	if _, err := extractTarGzFile("bin/mybinary", data); err == nil {
+		t.Fatal("expected error for invalid gzip checksum, got nil")
+	}
+}
+
 // TestExtractArchiveFileDispatch checks that each supported archive name is
 // routed to the correct extractor, including aliases and different casing.
 func TestExtractArchiveFileDispatch(t *testing.T) {
@@ -210,5 +228,15 @@ func TestValidArchiveType(t *testing.T) {
 		if validArchiveType(archiveType) {
 			t.Errorf("expected %q to be an invalid archive type", archiveType)
 		}
+	}
+}
+
+// TestReadArchiveEntrySizeLimit checks that extraction stops with an error
+// when an entry contains more data than the configured maximum size.
+func TestReadArchiveEntrySizeLimit(t *testing.T) {
+	reader := strings.NewReader(strings.Repeat("x", 11))
+
+	if _, err := readArchiveEntry(reader, "mybinary", 10); err == nil {
+		t.Fatal("expected error for oversized archive entry, got nil")
 	}
 }

--- a/pkgmgr/archive_test.go
+++ b/pkgmgr/archive_test.go
@@ -50,7 +50,10 @@ func buildTestZip(t *testing.T, entries map[string]string) []byte {
 func buildTestTarGz(t *testing.T, entries map[string]string) []byte {
 	t.Helper()
 	var buf bytes.Buffer
-	gzw := gzip.NewWriter(&buf)
+	gzw, err := gzip.NewWriterLevel(&buf, gzip.DefaultCompression)
+	if err != nil {
+		t.Fatalf("unexpected error creating gzip writer: %s", err)
+	}
 	gzw.Comment = "{{archive bytes must remain raw"
 	tw := tar.NewWriter(gzw)
 	for name, content := range entries {

--- a/pkgmgr/archive_test.go
+++ b/pkgmgr/archive_test.go
@@ -1,0 +1,214 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkgmgr
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"testing"
+)
+
+const testArchiveFileContent = "#!/bin/sh\necho hello\n"
+
+func buildTestZip(t *testing.T, entries map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, content := range entries {
+		fw, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("unexpected error creating zip entry: %s", err)
+		}
+		if _, err := fw.Write([]byte(content)); err != nil {
+			t.Fatalf("unexpected error writing zip entry: %s", err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("unexpected error closing zip writer: %s", err)
+	}
+	return buf.Bytes()
+}
+
+func buildTestTarGz(t *testing.T, entries map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzw)
+	for name, content := range entries {
+		hdr := &tar.Header{
+			Name: name,
+			Mode: 0o755,
+			Size: int64(len(content)),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("unexpected error writing tar header: %s", err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatalf("unexpected error writing tar entry: %s", err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("unexpected error closing tar writer: %s", err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatalf("unexpected error closing gzip writer: %s", err)
+	}
+	return buf.Bytes()
+}
+
+// TestExtractZipFile checks that the requested file is selected from a ZIP
+// archive and returned with its original content.
+func TestExtractZipFile(t *testing.T) {
+	data := buildTestZip(t, map[string]string{
+		"bin/mybinary": testArchiveFileContent,
+		"README.md":    "docs",
+	})
+
+	content, err := extractZipFile("bin/mybinary", data)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if string(content) != testArchiveFileContent {
+		t.Fatalf(
+			"did not get expected content\n  got: %q\n  expected: %q",
+			content,
+			testArchiveFileContent,
+		)
+	}
+}
+
+// TestExtractZipFileNotFound checks that ZIP extraction returns an error when
+// the requested file does not exist in the archive.
+func TestExtractZipFileNotFound(t *testing.T) {
+	data := buildTestZip(t, map[string]string{
+		"bin/mybinary": testArchiveFileContent,
+	})
+
+	if _, err := extractZipFile("bin/missing", data); err == nil {
+		t.Fatal("expected error for missing file in archive, got nil")
+	}
+}
+
+// TestExtractZipFileSkipsDirs checks that a ZIP directory entry is ignored
+// instead of being returned as an extracted file.
+func TestExtractZipFileSkipsDirs(t *testing.T) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	if _, err := zw.Create("bin/"); err != nil {
+		t.Fatalf("unexpected error creating zip dir entry: %s", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("unexpected error closing zip writer: %s", err)
+	}
+
+	if _, err := extractZipFile("bin", buf.Bytes()); err == nil {
+		t.Fatal("expected error when requested path is a directory, got nil")
+	}
+}
+
+// TestExtractTarGzFile checks that the requested file is selected from a
+// tar.gz archive and returned with its original content.
+func TestExtractTarGzFile(t *testing.T) {
+	data := buildTestTarGz(t, map[string]string{
+		"bin/mybinary": testArchiveFileContent,
+		"README.md":    "docs",
+	})
+
+	content, err := extractTarGzFile("bin/mybinary", data)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if string(content) != testArchiveFileContent {
+		t.Fatalf(
+			"did not get expected content\n  got: %q\n  expected: %q",
+			content,
+			testArchiveFileContent,
+		)
+	}
+}
+
+// TestExtractTarGzFileNotFound checks that tar.gz extraction returns an error
+// when the requested file does not exist in the archive.
+func TestExtractTarGzFileNotFound(t *testing.T) {
+	data := buildTestTarGz(t, map[string]string{
+		"bin/mybinary": testArchiveFileContent,
+	})
+
+	if _, err := extractTarGzFile("bin/missing", data); err == nil {
+		t.Fatal("expected error for missing file in archive, got nil")
+	}
+}
+
+// TestExtractArchiveFileDispatch checks that each supported archive name is
+// routed to the correct extractor, including aliases and different casing.
+func TestExtractArchiveFileDispatch(t *testing.T) {
+	zipData := buildTestZip(t, map[string]string{"mybinary": testArchiveFileContent})
+	tarGzData := buildTestTarGz(t, map[string]string{"mybinary": testArchiveFileContent})
+
+	testDefs := []struct {
+		archiveType string
+		data        []byte
+	}{
+		{archiveType: "zip", data: zipData},
+		{archiveType: "ZIP", data: zipData},
+		{archiveType: "tar.gz", data: tarGzData},
+		{archiveType: "tgz", data: tarGzData},
+	}
+	for _, testDef := range testDefs {
+		content, err := extractArchiveFile(testDef.archiveType, "mybinary", testDef.data)
+		if err != nil {
+			t.Fatalf(
+				"unexpected error for archive type %q: %s",
+				testDef.archiveType,
+				err,
+			)
+		}
+		if string(content) != testArchiveFileContent {
+			t.Fatalf(
+				"did not get expected content for archive type %q\n  got: %q\n  expected: %q",
+				testDef.archiveType,
+				content,
+				testArchiveFileContent,
+			)
+		}
+	}
+}
+
+// TestExtractArchiveFileUnsupportedType checks that extraction fails clearly
+// when an unsupported archive format is requested.
+func TestExtractArchiveFileUnsupportedType(t *testing.T) {
+	if _, err := extractArchiveFile("rar", "mybinary", nil); err == nil {
+		t.Fatal("expected error for unsupported archive type, got nil")
+	}
+}
+
+// TestValidArchiveType checks that supported archive names are accepted and
+// unknown or empty archive names are rejected.
+func TestValidArchiveType(t *testing.T) {
+	validTypes := []string{"zip", "ZIP", "tar.gz", "TAR.GZ", "tgz"}
+	for _, archiveType := range validTypes {
+		if !validArchiveType(archiveType) {
+			t.Errorf("expected %q to be a valid archive type", archiveType)
+		}
+	}
+	invalidTypes := []string{"", "rar", "7z"}
+	for _, archiveType := range invalidTypes {
+		if validArchiveType(archiveType) {
+			t.Errorf("expected %q to be an invalid archive type", archiveType)
+		}
+	}
+}

--- a/pkgmgr/archive_test.go
+++ b/pkgmgr/archive_test.go
@@ -19,6 +19,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"compress/gzip"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -56,7 +57,13 @@ func buildTestTarGz(t *testing.T, entries map[string]string) []byte {
 	}
 	gzw.Comment = "{{archive bytes must remain raw"
 	tw := tar.NewWriter(gzw)
-	for name, content := range entries {
+	names := make([]string, 0, len(entries))
+	for name := range entries {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		content := entries[name]
 		hdr := &tar.Header{
 			Name: name,
 			Mode: 0o755,
@@ -171,6 +178,19 @@ func TestExtractTarGzFileCorruptChecksum(t *testing.T) {
 
 	if _, err := extractTarGzFile("bin/mybinary", data); err == nil {
 		t.Fatal("expected error for invalid gzip checksum, got nil")
+	}
+}
+
+// TestExtractTarGzFileCumulativeSizeLimit checks that later tar entries cannot
+// exceed the total decompressed-data limit after a small entry is selected.
+func TestExtractTarGzFileCumulativeSizeLimit(t *testing.T) {
+	data := buildTestTarGz(t, map[string]string{
+		"first":  "small",
+		"second": strings.Repeat("x", 2048),
+	})
+
+	if _, err := extractTarGzFileWithLimit("first", data, 2048); err == nil {
+		t.Fatal("expected error for oversized decompressed archive, got nil")
 	}
 }
 

--- a/pkgmgr/archive_test.go
+++ b/pkgmgr/archive_test.go
@@ -189,8 +189,12 @@ func TestExtractTarGzFileCumulativeSizeLimit(t *testing.T) {
 		"second": strings.Repeat("x", 2048),
 	})
 
-	if _, err := extractTarGzFileWithLimit("first", data, 2048); err == nil {
+	_, err := extractTarGzFileWithLimit("first", data, 2048)
+	if err == nil {
 		t.Fatal("expected error for oversized decompressed archive, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum decompressed size") {
+		t.Fatalf("unexpected error for oversized decompressed archive: %s", err)
 	}
 }
 

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -1076,11 +1076,11 @@ func (p *PackageInstallStepFile) install(
 		if resp == nil {
 			return fmt.Errorf("nil response for URL: %s", tmpUrl)
 		}
-		respBody, err := io.ReadAll(resp.Body)
+		defer resp.Body.Close()
+		respBody, err := readArchiveEntry(resp.Body, tmpUrl, maxDownloadSize)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to download %q: %w", tmpUrl, err)
 		}
-		resp.Body.Close()
 
 		fileContent = respBody
 	} else {

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -1038,11 +1038,16 @@ func (p *PackageInstallStepFile) install(
 		if err != nil {
 			return err
 		}
-		tmpContent, err := cfg.Template.Render(string(tmpContentBytes), nil)
-		if err != nil {
-			return err
+		if p.Archive != "" {
+			// Archive data is binary and must not be interpreted as a template.
+			fileContent = tmpContentBytes
+		} else {
+			tmpContent, err := cfg.Template.Render(string(tmpContentBytes), nil)
+			if err != nil {
+				return err
+			}
+			fileContent = []byte(tmpContent)
 		}
-		fileContent = []byte(tmpContent)
 	} else if p.Url != "" {
 		tmpUrl, err := cfg.Template.Render(p.Url, nil)
 		if err != nil {

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -1034,14 +1034,26 @@ func (p *PackageInstallStepFile) install(
 			filepath.Dir(packagePath),
 			p.Source,
 		)
-		tmpContentBytes, err := os.ReadFile(fullSourcePath)
-		if err != nil {
-			return err
-		}
 		if p.Archive != "" {
 			// Archive data is binary and must not be interpreted as a template.
+			// Bound the read the same way as url-sourced downloads, so a
+			// malformed or oversized package asset can't be fully buffered
+			// into memory before the archive-entry limit even runs.
+			sourceFile, err := os.Open(fullSourcePath)
+			if err != nil {
+				return err
+			}
+			defer sourceFile.Close()
+			tmpContentBytes, err := readArchiveEntry(sourceFile, fullSourcePath, maxDownloadSize)
+			if err != nil {
+				return fmt.Errorf("failed to read %q: %w", fullSourcePath, err)
+			}
 			fileContent = tmpContentBytes
 		} else {
+			tmpContentBytes, err := os.ReadFile(fullSourcePath)
+			if err != nil {
+				return err
+			}
 			tmpContent, err := cfg.Template.Render(string(tmpContentBytes), nil)
 			if err != nil {
 				return err

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -983,6 +983,10 @@ func (p *PackageInstallStepFile) validate(cfg Config) error {
 		return errors.New("packages must provide content, source, or url for file install types")
 	}
 	if p.Archive != "" {
+		if p.Content != "" {
+			cfg.Logger.Debug("archive combined with content")
+			return errors.New("archive cannot be combined with content; use source or url")
+		}
 		if !validArchiveType(p.Archive) {
 			cfg.Logger.Debug("unsupported archive type: " + p.Archive)
 			return fmt.Errorf("unsupported archive type %q", p.Archive)

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -967,16 +967,31 @@ func (p *PackageInstallStepDocker) deactivate(
 }
 
 type PackageInstallStepFile struct {
-	Binary   bool        `yaml:"binary"`
-	Filename string      `yaml:"filename"`
-	Source   string      `yaml:"source"`
-	Content  string      `yaml:"content"`
-	Url      string      `yaml:"url"`
-	Mode     fs.FileMode `yaml:"mode,omitempty"`
+	Binary      bool        `yaml:"binary"`
+	Filename    string      `yaml:"filename"`
+	Source      string      `yaml:"source"`
+	Content     string      `yaml:"content"`
+	Url         string      `yaml:"url"`
+	Mode        fs.FileMode `yaml:"mode,omitempty"`
+	Archive     string      `yaml:"archive,omitempty"`
+	ArchivePath string      `yaml:"archivePath,omitempty"`
 }
 
 func (p *PackageInstallStepFile) validate(cfg Config) error {
-	// TODO: add checks
+	if p.Content == "" && p.Source == "" && p.Url == "" {
+		cfg.Logger.Debug("file install step missing content, source, and url")
+		return errors.New("packages must provide content, source, or url for file install types")
+	}
+	if p.Archive != "" {
+		if !validArchiveType(p.Archive) {
+			cfg.Logger.Debug("unsupported archive type: " + p.Archive)
+			return fmt.Errorf("unsupported archive type %q", p.Archive)
+		}
+		if p.ArchivePath == "" {
+			cfg.Logger.Debug("archive set without archivePath")
+			return errors.New("archivePath must be provided when archive is set")
+		}
+	}
 	return nil
 }
 
@@ -1029,8 +1044,13 @@ func (p *PackageInstallStepFile) install(
 		}
 		fileContent = []byte(tmpContent)
 	} else if p.Url != "" {
+		tmpUrl, err := cfg.Template.Render(p.Url, nil)
+		if err != nil {
+			return err
+		}
+
 		// Validate URL
-		u, err := url.Parse(p.Url)
+		u, err := url.Parse(tmpUrl)
 		if err != nil {
 			return err
 		}
@@ -1040,7 +1060,7 @@ func (p *PackageInstallStepFile) install(
 
 		// Fetch data
 		ctx := context.Background()
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.Url, nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, tmpUrl, nil)
 		if err != nil {
 			return err
 		}
@@ -1049,7 +1069,7 @@ func (p *PackageInstallStepFile) install(
 			return err
 		}
 		if resp == nil {
-			return fmt.Errorf("nil response for URL: %s", p.Url)
+			return fmt.Errorf("nil response for URL: %s", tmpUrl)
 		}
 		respBody, err := io.ReadAll(resp.Body)
 		if err != nil {
@@ -1060,6 +1080,16 @@ func (p *PackageInstallStepFile) install(
 		fileContent = respBody
 	} else {
 		return errors.New("packages must provide content, source, or url for file install types")
+	}
+	if p.Archive != "" {
+		tmpArchivePath, err := cfg.Template.Render(p.ArchivePath, nil)
+		if err != nil {
+			return err
+		}
+		fileContent, err = extractArchiveFile(p.Archive, tmpArchivePath, fileContent)
+		if err != nil {
+			return fmt.Errorf("failed to extract %q from archive: %w", tmpArchivePath, err)
+		}
 	}
 	if err := os.WriteFile(filePath, fileContent, fileMode); err != nil { //nolint:gosec // path traversal mitigated by prefix check above
 		return err

--- a/pkgmgr/package_archive_test.go
+++ b/pkgmgr/package_archive_test.go
@@ -1,0 +1,395 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkgmgr
+
+import (
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"text/template"
+)
+
+func newArchiveTestConfig(t *testing.T) Config {
+	t.Helper()
+	tmpDir := t.TempDir()
+	return Config{
+		CacheDir: tmpDir,
+		DataDir:  tmpDir,
+		BinDir:   filepath.Join(tmpDir, "bin"),
+		Logger:   slog.New(slog.NewTextHandler(os.Stderr, nil)),
+		Template: &Template{
+			tmpl:     template.New("test"),
+			baseVars: make(map[string]any),
+		},
+	}
+}
+
+// TestPackageInstallStepFileValidate checks valid and invalid file-step archive
+// configurations, including missing inputs, paths, and unsupported formats.
+func TestPackageInstallStepFileValidate(t *testing.T) {
+	testDefs := []struct {
+		step      PackageInstallStepFile
+		expectErr bool
+	}{
+		{
+			step:      PackageInstallStepFile{Content: "foo"},
+			expectErr: false,
+		},
+		{
+			step:      PackageInstallStepFile{},
+			expectErr: true,
+		},
+		{
+			step: PackageInstallStepFile{
+				Url:     "https://example.com/foo.zip",
+				Archive: "zip",
+			},
+			expectErr: true, // missing archivePath
+		},
+		{
+			step: PackageInstallStepFile{
+				Url:     "https://example.com/foo.zip",
+				Archive: "rar",
+			},
+			expectErr: true, // unsupported archive type
+		},
+		{
+			step: PackageInstallStepFile{
+				Url:         "https://example.com/foo.zip",
+				Archive:     "zip",
+				ArchivePath: "bin/foo",
+			},
+			expectErr: false,
+		},
+	}
+	cfg := newArchiveTestConfig(t)
+	for _, testDef := range testDefs {
+		err := testDef.step.validate(cfg)
+		if testDef.expectErr && err == nil {
+			t.Errorf("expected error for step %#v, got nil", testDef.step)
+		}
+		if !testDef.expectErr && err != nil {
+			t.Errorf("unexpected error for step %#v: %s", testDef.step, err)
+		}
+	}
+}
+
+// TestPackageInstallStepFileInstallArchiveZip checks that one binary is selected
+// from a ZIP archive, installed with its content, and linked on activation.
+func TestPackageInstallStepFileInstallArchiveZip(t *testing.T) {
+	cfg := newArchiveTestConfig(t)
+	pkgSourceDir := t.TempDir()
+	zipPath := filepath.Join(pkgSourceDir, "release.zip")
+	zipData := buildTestZip(t, map[string]string{
+		"bin/mybinary": testArchiveFileContent,
+	})
+	if err := os.WriteFile(zipPath, zipData, 0o644); err != nil {
+		t.Fatalf("unexpected error writing test zip: %s", err)
+	}
+
+	step := &PackageInstallStepFile{
+		Filename:    "mybinary",
+		Source:      "release.zip",
+		Binary:      true,
+		Mode:        0o755,
+		Archive:     "zip",
+		ArchivePath: "bin/mybinary",
+	}
+	packagePath := filepath.Join(pkgSourceDir, "test-1.0.0.yaml")
+	if err := step.install(cfg, "test-1.0.0-testctx", packagePath); err != nil {
+		t.Fatalf("install failed: %s", err)
+	}
+
+	writtenPath := filepath.Join(cfg.DataDir, "test-1.0.0-testctx", "mybinary")
+	content, err := os.ReadFile(writtenPath)
+	if err != nil {
+		t.Fatalf("unexpected error reading installed file: %s", err)
+	}
+	if string(content) != testArchiveFileContent {
+		t.Fatalf(
+			"did not get expected content\n  got: %q\n  expected: %q",
+			content,
+			testArchiveFileContent,
+		)
+	}
+
+	if err := step.activate(cfg, "test-1.0.0-testctx"); err != nil {
+		t.Fatalf("activate failed: %s", err)
+	}
+	binPath := filepath.Join(cfg.BinDir, "mybinary")
+	linkTarget, err := os.Readlink(binPath)
+	if err != nil {
+		t.Fatalf("unexpected error reading symlink: %s", err)
+	}
+	if linkTarget != writtenPath {
+		t.Fatalf(
+			"symlink target mismatch\n  got: %s\n  expected: %s",
+			linkTarget,
+			writtenPath,
+		)
+	}
+}
+
+// TestPackageInstallStepFileInstallArchiveTarGz checks that one binary can be
+// selected from a tar.gz archive and written to the package data directory.
+func TestPackageInstallStepFileInstallArchiveTarGz(t *testing.T) {
+	cfg := newArchiveTestConfig(t)
+	pkgSourceDir := t.TempDir()
+	tarGzPath := filepath.Join(pkgSourceDir, "release.tar.gz")
+	tarGzData := buildTestTarGz(t, map[string]string{
+		"mybinary": testArchiveFileContent,
+	})
+	if err := os.WriteFile(tarGzPath, tarGzData, 0o644); err != nil {
+		t.Fatalf("unexpected error writing test tar.gz: %s", err)
+	}
+
+	step := &PackageInstallStepFile{
+		Filename:    "mybinary",
+		Source:      "release.tar.gz",
+		Binary:      true,
+		Mode:        0o755,
+		Archive:     "tar.gz",
+		ArchivePath: "mybinary",
+	}
+	packagePath := filepath.Join(pkgSourceDir, "test-1.0.0.yaml")
+	if err := step.install(cfg, "test-1.0.0-testctx", packagePath); err != nil {
+		t.Fatalf("install failed: %s", err)
+	}
+
+	writtenPath := filepath.Join(cfg.DataDir, "test-1.0.0-testctx", "mybinary")
+	content, err := os.ReadFile(writtenPath)
+	if err != nil {
+		t.Fatalf("unexpected error reading installed file: %s", err)
+	}
+	if string(content) != testArchiveFileContent {
+		t.Fatalf(
+			"did not get expected content\n  got: %q\n  expected: %q",
+			content,
+			testArchiveFileContent,
+		)
+	}
+}
+
+// TestPackageInstallStepFileInstallArchiveMissingEntry checks that installation
+// fails when archivePath does not identify a file contained in the archive.
+func TestPackageInstallStepFileInstallArchiveMissingEntry(t *testing.T) {
+	cfg := newArchiveTestConfig(t)
+	pkgSourceDir := t.TempDir()
+	zipPath := filepath.Join(pkgSourceDir, "release.zip")
+	zipData := buildTestZip(t, map[string]string{
+		"bin/other": testArchiveFileContent,
+	})
+	if err := os.WriteFile(zipPath, zipData, 0o644); err != nil {
+		t.Fatalf("unexpected error writing test zip: %s", err)
+	}
+
+	step := &PackageInstallStepFile{
+		Filename:    "mybinary",
+		Source:      "release.zip",
+		Archive:     "zip",
+		ArchivePath: "bin/mybinary",
+	}
+	packagePath := filepath.Join(pkgSourceDir, "test-1.0.0.yaml")
+	if err := step.install(cfg, "test-1.0.0-testctx", packagePath); err == nil {
+		t.Fatal("expected error for missing archive entry, got nil")
+	}
+}
+
+// TestPackageInstallStepFileInstallUrlArchive checks downloading a templated
+// tar.gz URL, extracting its binary, and linking the binary on activation.
+func TestPackageInstallStepFileInstallUrlArchive(t *testing.T) {
+	tarGzData := buildTestTarGz(t, map[string]string{
+		"mybinary": testArchiveFileContent,
+	})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/releases/mybinary-linux-amd64.tar.gz" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Write(tarGzData) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	cfg := newArchiveTestConfig(t)
+	cfg.Template = cfg.Template.WithVars(
+		map[string]any{
+			"System": map[string]string{
+				"OS":   "linux",
+				"ARCH": "amd64",
+			},
+		},
+	)
+
+	step := &PackageInstallStepFile{
+		Filename:    "mybinary",
+		Binary:      true,
+		Mode:        0o755,
+		Url:         srv.URL + "/releases/mybinary-{{ .System.OS }}-{{ .System.ARCH }}.tar.gz",
+		Archive:     "tar.gz",
+		ArchivePath: "mybinary",
+	}
+	if err := step.install(cfg, "test-1.0.0-testctx", ""); err != nil {
+		t.Fatalf("install failed: %s", err)
+	}
+
+	writtenPath := filepath.Join(cfg.DataDir, "test-1.0.0-testctx", "mybinary")
+	content, err := os.ReadFile(writtenPath)
+	if err != nil {
+		t.Fatalf("unexpected error reading installed file: %s", err)
+	}
+	if string(content) != testArchiveFileContent {
+		t.Fatalf(
+			"did not get expected content\n  got: %q\n  expected: %q",
+			content,
+			testArchiveFileContent,
+		)
+	}
+
+	if err := step.activate(cfg, "test-1.0.0-testctx"); err != nil {
+		t.Fatalf("activate failed: %s", err)
+	}
+	binPath := filepath.Join(cfg.BinDir, "mybinary")
+	linkTarget, err := os.Readlink(binPath)
+	if err != nil {
+		t.Fatalf("unexpected error reading symlink: %s", err)
+	}
+	if linkTarget != writtenPath {
+		t.Fatalf(
+			"symlink target mismatch\n  got: %s\n  expected: %s",
+			linkTarget,
+			writtenPath,
+		)
+	}
+}
+
+// TestPackageInstallStepFileInstallArchivePathTemplated checks that OS and
+// architecture values are rendered when selecting a file inside an archive.
+func TestPackageInstallStepFileInstallArchivePathTemplated(t *testing.T) {
+	cfg := newArchiveTestConfig(t)
+	cfg.Template = cfg.Template.WithVars(
+		map[string]any{
+			"System": map[string]string{
+				"OS":   "linux",
+				"ARCH": "amd64",
+			},
+		},
+	)
+	pkgSourceDir := t.TempDir()
+	zipPath := filepath.Join(pkgSourceDir, "release.zip")
+	zipData := buildTestZip(t, map[string]string{
+		"bin/linux-amd64/mybinary": testArchiveFileContent,
+	})
+	if err := os.WriteFile(zipPath, zipData, 0o644); err != nil {
+		t.Fatalf("unexpected error writing test zip: %s", err)
+	}
+
+	step := &PackageInstallStepFile{
+		Filename:    "mybinary",
+		Source:      "release.zip",
+		Archive:     "zip",
+		ArchivePath: "bin/{{ .System.OS }}-{{ .System.ARCH }}/mybinary",
+	}
+	packagePath := filepath.Join(pkgSourceDir, "test-1.0.0.yaml")
+	if err := step.install(cfg, "test-1.0.0-testctx", packagePath); err != nil {
+		t.Fatalf("install failed: %s", err)
+	}
+
+	writtenPath := filepath.Join(cfg.DataDir, "test-1.0.0-testctx", "mybinary")
+	content, err := os.ReadFile(writtenPath)
+	if err != nil {
+		t.Fatalf("unexpected error reading installed file: %s", err)
+	}
+	if string(content) != testArchiveFileContent {
+		t.Fatalf(
+			"did not get expected content\n  got: %q\n  expected: %q",
+			content,
+			testArchiveFileContent,
+		)
+	}
+}
+
+// TestPackageInstallStepFileInstallUrlTemplated checks that OS and architecture
+// template values are correctly substituted into a binary download URL.
+func TestPackageInstallStepFileInstallUrlTemplated(t *testing.T) {
+	cfg := newArchiveTestConfig(t)
+	cfg.Template = cfg.Template.WithVars(
+		map[string]any{
+			"System": map[string]string{
+				"OS":   "linux",
+				"ARCH": "amd64",
+			},
+		},
+	)
+	// Render the URL template directly to confirm OS/ARCH substitution works
+	// as expected for the file install step's url field
+	rendered, err := cfg.Template.Render(
+		"https://example.com/mybinary-{{ .System.OS }}-{{ .System.ARCH }}",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error rendering url template: %s", err)
+	}
+	expected := "https://example.com/mybinary-linux-amd64"
+	if rendered != expected {
+		t.Fatalf(
+			"did not get expected rendered url\n  got: %s\n  expected: %s",
+			rendered,
+			expected,
+		)
+	}
+}
+
+// TestPackageInstallStepFileInstallArchiveModePreserved checks that the requested
+// file permissions are applied to the binary extracted from an archive.
+func TestPackageInstallStepFileInstallArchiveModePreserved(t *testing.T) {
+	cfg := newArchiveTestConfig(t)
+	pkgSourceDir := t.TempDir()
+	zipPath := filepath.Join(pkgSourceDir, "release.zip")
+	zipData := buildTestZip(t, map[string]string{
+		"mybinary": testArchiveFileContent,
+	})
+	if err := os.WriteFile(zipPath, zipData, 0o644); err != nil {
+		t.Fatalf("unexpected error writing test zip: %s", err)
+	}
+
+	step := &PackageInstallStepFile{
+		Filename:    "mybinary",
+		Source:      "release.zip",
+		Mode:        0o755,
+		Archive:     "zip",
+		ArchivePath: "mybinary",
+	}
+	packagePath := filepath.Join(pkgSourceDir, "test-1.0.0.yaml")
+	if err := step.install(cfg, "test-1.0.0-testctx", packagePath); err != nil {
+		t.Fatalf("install failed: %s", err)
+	}
+
+	writtenPath := filepath.Join(cfg.DataDir, "test-1.0.0-testctx", "mybinary")
+	stat, err := os.Stat(writtenPath)
+	if err != nil {
+		t.Fatalf("unexpected error statting installed file: %s", err)
+	}
+	if stat.Mode().Perm() != fs.FileMode(0o755) {
+		t.Fatalf(
+			"unexpected file mode: got %o, expected %o",
+			stat.Mode().Perm(),
+			0o755,
+		)
+	}
+}

--- a/pkgmgr/package_archive_test.go
+++ b/pkgmgr/package_archive_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"text/template"
 )
@@ -315,6 +316,37 @@ func TestPackageInstallStepFileInstallUrlArchive(t *testing.T) {
 			linkTarget,
 			writtenPath,
 		)
+	}
+}
+
+// TestPackageInstallStepFileInstallUrlDownloadSizeLimit checks that install
+// aborts once a url-sourced download exceeds maxDownloadSize, instead of
+// buffering the full oversized response into memory.
+func TestPackageInstallStepFileInstallUrlDownloadSizeLimit(t *testing.T) {
+	origMaxDownloadSize := maxDownloadSize
+	maxDownloadSize = 10
+	t.Cleanup(func() {
+		maxDownloadSize = origMaxDownloadSize
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(strings.Repeat("x", 100))) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	cfg := newArchiveTestConfig(t)
+	step := &PackageInstallStepFile{
+		Filename: "mybinary",
+		Url:      srv.URL + "/mybinary",
+	}
+	err := step.install(cfg, "test-1.0.0-testctx", "")
+	if err == nil {
+		t.Fatal("expected error for oversized download, got nil")
+	}
+
+	writtenPath := filepath.Join(cfg.DataDir, "test-1.0.0-testctx", "mybinary")
+	if _, statErr := os.Stat(writtenPath); statErr == nil {
+		t.Fatal("expected no file to be written for oversized download")
 	}
 }
 

--- a/pkgmgr/package_archive_test.go
+++ b/pkgmgr/package_archive_test.go
@@ -396,9 +396,18 @@ func TestPackageInstallStepFileInstallArchivePathTemplated(t *testing.T) {
 	}
 }
 
-// TestPackageInstallStepFileInstallUrlTemplated checks that OS and architecture
-// template values are correctly substituted into a binary download URL.
+// TestPackageInstallStepFileInstallUrlTemplated checks that install renders
+// OS and architecture values into the url field before issuing the HTTP
+// request, so the server actually receives the platform-specific path.
 func TestPackageInstallStepFileInstallUrlTemplated(t *testing.T) {
+	const expectedContent = "binary content"
+	var requestedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.Path
+		w.Write([]byte(expectedContent)) //nolint:errcheck
+	}))
+	defer srv.Close()
+
 	cfg := newArchiveTestConfig(t)
 	cfg.Template = cfg.Template.WithVars(
 		map[string]any{
@@ -408,22 +417,73 @@ func TestPackageInstallStepFileInstallUrlTemplated(t *testing.T) {
 			},
 		},
 	)
-	// Render the URL template directly to confirm OS/ARCH substitution works
-	// as expected for the file install step's url field
-	rendered, err := cfg.Template.Render(
-		"https://example.com/mybinary-{{ .System.OS }}-{{ .System.ARCH }}",
-		nil,
-	)
-	if err != nil {
-		t.Fatalf("unexpected error rendering url template: %s", err)
+
+	step := &PackageInstallStepFile{
+		Filename: "mybinary",
+		Url:      srv.URL + "/mybinary-{{ .System.OS }}-{{ .System.ARCH }}",
 	}
-	expected := "https://example.com/mybinary-linux-amd64"
-	if rendered != expected {
+	if err := step.install(cfg, "test-1.0.0-testctx", ""); err != nil {
+		t.Fatalf("install failed: %s", err)
+	}
+
+	expectedPath := "/mybinary-linux-amd64"
+	if requestedPath != expectedPath {
 		t.Fatalf(
-			"did not get expected rendered url\n  got: %s\n  expected: %s",
-			rendered,
-			expected,
+			"did not get expected requested path\n  got: %s\n  expected: %s",
+			requestedPath,
+			expectedPath,
 		)
+	}
+
+	writtenPath := filepath.Join(cfg.DataDir, "test-1.0.0-testctx", "mybinary")
+	content, err := os.ReadFile(writtenPath)
+	if err != nil {
+		t.Fatalf("unexpected error reading installed file: %s", err)
+	}
+	if string(content) != expectedContent {
+		t.Fatalf(
+			"did not get expected content\n  got: %q\n  expected: %q",
+			content,
+			expectedContent,
+		)
+	}
+}
+
+// TestPackageInstallStepFileInstallSourceArchiveSizeLimit checks that install
+// aborts once a source-backed archive file exceeds maxDownloadSize, instead
+// of buffering the full oversized file into memory.
+func TestPackageInstallStepFileInstallSourceArchiveSizeLimit(t *testing.T) {
+	origMaxDownloadSize := maxDownloadSize
+	maxDownloadSize = 10
+	t.Cleanup(func() {
+		maxDownloadSize = origMaxDownloadSize
+	})
+
+	pkgSourceDir := t.TempDir()
+	zipPath := filepath.Join(pkgSourceDir, "release.zip")
+	zipData := buildTestZip(t, map[string]string{
+		"mybinary": strings.Repeat("x", 100),
+	})
+	if err := os.WriteFile(zipPath, zipData, 0o644); err != nil {
+		t.Fatalf("unexpected error writing test zip: %s", err)
+	}
+
+	cfg := newArchiveTestConfig(t)
+	step := &PackageInstallStepFile{
+		Filename:    "mybinary",
+		Source:      "release.zip",
+		Archive:     "zip",
+		ArchivePath: "mybinary",
+	}
+	packagePath := filepath.Join(pkgSourceDir, "test-1.0.0.yaml")
+	err := step.install(cfg, "test-1.0.0-testctx", packagePath)
+	if err == nil {
+		t.Fatal("expected error for oversized source archive, got nil")
+	}
+
+	writtenPath := filepath.Join(cfg.DataDir, "test-1.0.0-testctx", "mybinary")
+	if _, statErr := os.Stat(writtenPath); statErr == nil {
+		t.Fatal("expected no file to be written for oversized source archive")
 	}
 }
 

--- a/pkgmgr/package_archive_test.go
+++ b/pkgmgr/package_archive_test.go
@@ -186,6 +186,46 @@ func TestPackageInstallStepFileInstallArchiveTarGz(t *testing.T) {
 	}
 }
 
+// TestPackageInstallStepFileInstallArchiveTgz checks that the tgz alias works
+// end to end when extracting and installing one binary from an archive.
+func TestPackageInstallStepFileInstallArchiveTgz(t *testing.T) {
+	cfg := newArchiveTestConfig(t)
+	pkgSourceDir := t.TempDir()
+	tgzPath := filepath.Join(pkgSourceDir, "release.tgz")
+	tgzData := buildTestTarGz(t, map[string]string{
+		"mybinary": testArchiveFileContent,
+	})
+	if err := os.WriteFile(tgzPath, tgzData, 0o644); err != nil {
+		t.Fatalf("unexpected error writing test tgz: %s", err)
+	}
+
+	step := &PackageInstallStepFile{
+		Filename:    "mybinary",
+		Source:      "release.tgz",
+		Binary:      true,
+		Mode:        0o755,
+		Archive:     "tgz",
+		ArchivePath: "mybinary",
+	}
+	packagePath := filepath.Join(pkgSourceDir, "test-1.0.0.yaml")
+	if err := step.install(cfg, "test-1.0.0-testctx", packagePath); err != nil {
+		t.Fatalf("install failed: %s", err)
+	}
+
+	writtenPath := filepath.Join(cfg.DataDir, "test-1.0.0-testctx", "mybinary")
+	content, err := os.ReadFile(writtenPath)
+	if err != nil {
+		t.Fatalf("unexpected error reading installed file: %s", err)
+	}
+	if string(content) != testArchiveFileContent {
+		t.Fatalf(
+			"did not get expected content\n  got: %q\n  expected: %q",
+			content,
+			testArchiveFileContent,
+		)
+	}
+}
+
 // TestPackageInstallStepFileInstallArchiveMissingEntry checks that installation
 // fails when archivePath does not identify a file contained in the archive.
 func TestPackageInstallStepFileInstallArchiveMissingEntry(t *testing.T) {

--- a/pkgmgr/package_archive_test.go
+++ b/pkgmgr/package_archive_test.go
@@ -78,6 +78,14 @@ func TestPackageInstallStepFileValidate(t *testing.T) {
 			},
 			expectErr: false,
 		},
+		{
+			step: PackageInstallStepFile{
+				Content:     "foo",
+				Archive:     "zip",
+				ArchivePath: "bin/foo",
+			},
+			expectErr: true, // archive cannot be combined with content
+		},
 	}
 	cfg := newArchiveTestConfig(t)
 	for _, testDef := range testDefs {


### PR DESCRIPTION
1. Added support for downloading and installing a single binary directly or from a `ZIP`, `tar.gz`, or `tgz` archive.
2. Added `archive` and `archivePath` fields to file installation steps.
3. Added support for `zip`, `tar.gz`, and `tgz` archives.
4. Added logic to extract only the requested file instead of the entire archive.
5. Added template rendering for download URLs and paths inside archives.
6. Added validation for unsupported archive formats.
7. Added validation requiring `archivePath` when `archive` is set.
8. Added validation requiring `content`, `source`, or `url`.
9. Preserved configured file permissions such as `0755`.
10. Reused the existing `binary: true` activation flow to create a binary symlink.
11. Added README documentation and a package manifest example.
12. Added unit tests for ZIP and compressed tarball extraction.
13. Added installation tests covering downloads, extraction, permissions, templates, and activation.

Closes #200 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds installing a single binary from a direct download or by extracting it from `zip`, `tar.gz`, or `tgz` archives, with templated URLs and archive paths. Fulfills Linear #200 with strict size limits, checksum verification, and safe ZIP handling.

- **New Features**
  - Add `url`, `archive`, and `archivePath` to file steps; `url` and `archivePath` support templating.
  - Download directly or extract only the selected file from `zip`, `tar.gz`, or `tgz`; archive bytes are never templated.
  - Enforce 512 MiB per-entry and download caps; verify gzip checksums; preserve file mode; reuse `binary: true` activation.
  - README updated; tests cover downloads, extraction, templates, permissions, activation, limits, and checksums.

- **Bug Fixes**
  - Validation tightened: require one of `content`/`source`/`url`; require `archivePath` with `archive`; reject unsupported formats; disallow combining `archive` with `content`.
  - Hardened IO and extraction: handle nil HTTP responses; bound URL/source reads with early failure; fixed `tar.gz` trailing-entry and cumulative-limit handling; ignore ZIP symlinks and other non-regular entries.

<sup>Written for commit e63c1d97cfe12f4f462517ba6e7d2e02094b5345. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up/pull/561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File installation steps can now download files from URLs.
  * Supports extracting selected files from `zip`, `tar.gz`, and `tgz` archives.
  * Archive paths and URLs support template variables.
  * Added configuration options for archive type and target file path.
* **Documentation**
  * Expanded installation guidance with URL and archive examples.
  * Clarified precedence when `source`, `content`, and `url` are combined.
* **Bug Fixes**
  * Improved validation and handling of invalid URLs, archive types, and missing archive files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->