### PR TITLE
fix(pkgmgr): update context environment ports after restart

### DIFF
--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -148,7 +148,7 @@ func (p Package) install(
 	runHooks bool,
 	registeredPorts PackagePortRegistry,
 ) (string, map[string]string, PackagePortRegistry, error) {
-	// Update template vars
+	cfg = p.withPackageTemplateVars(cfg, context, opts)
 	pkgName := fmt.Sprintf("%s-%s-%s", p.Name, p.Version, context)
 	pkgCacheDir := filepath.Join(
 		cfg.CacheDir,
@@ -161,26 +161,6 @@ func (p Package) install(
 	pkgDataDir := filepath.Join(
 		cfg.DataDir,
 		pkgName,
-	)
-	cfg.Template = cfg.Template.WithVars(
-		map[string]any{
-			"Package": map[string]any{
-				"Name":      pkgName,
-				"ShortName": p.Name,
-				"Version":   p.Version,
-				"Options":   opts,
-			},
-			"Paths": map[string]string{
-				"BinDir":     cfg.BinDir,
-				"CacheDir":   pkgCacheDir,
-				"ContextDir": pkgContextDir,
-				"DataDir":    pkgDataDir,
-			},
-			"System": map[string]string{
-				"OS":   runtime.GOOS,
-				"ARCH": runtime.GOARCH,
-			},
-		},
 	)
 	// Run pre-flight checks
 	for _, installStep := range p.InstallSteps {
@@ -244,11 +224,88 @@ func (p Package) install(
 		}
 	}
 	// Capture port details for output templates
-	retPorts := make(PackagePortRegistry)
-	tmpServices, err := p.services(cfg, context)
+	retPorts, err := p.currentPorts(cfg, context)
 	if err != nil {
 		return "", nil, nil, err
 	}
+	cfg.Template = cfg.Template.WithVars(
+		map[string]any{
+			"Ports": retPorts,
+		},
+	)
+	retOutputs, err := p.renderOutputs(cfg, retPorts)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	// Run post-install script
+	if runHooks && p.PostInstallScript != "" {
+		if err := p.runHookScript(cfg, p.PostInstallScript); err != nil {
+			return "", nil, nil, err
+		}
+	}
+	// Render notes and return
+	var retNotes string
+	if p.PostInstallNotes != "" {
+		tmpNotes, err := cfg.Template.Render(p.PostInstallNotes, nil)
+		if err != nil {
+			return "", nil, nil, err
+		}
+		retNotes = tmpNotes
+	}
+	return retNotes, retOutputs, retPorts, nil
+}
+
+func (p Package) withPackageTemplateVars(
+	cfg Config,
+	context string,
+	opts map[string]bool,
+) Config {
+	pkgName := fmt.Sprintf("%s-%s-%s", p.Name, p.Version, context)
+	pkgCacheDir := filepath.Join(
+		cfg.CacheDir,
+		pkgName,
+	)
+	pkgContextDir := filepath.Join(
+		cfg.DataDir,
+		context,
+	)
+	pkgDataDir := filepath.Join(
+		cfg.DataDir,
+		pkgName,
+	)
+	cfg.Template = cfg.Template.WithVars(
+		map[string]any{
+			"Package": map[string]any{
+				"Name":      pkgName,
+				"ShortName": p.Name,
+				"Version":   p.Version,
+				"Options":   opts,
+			},
+			"Paths": map[string]string{
+				"BinDir":     cfg.BinDir,
+				"CacheDir":   pkgCacheDir,
+				"ContextDir": pkgContextDir,
+				"DataDir":    pkgDataDir,
+			},
+			"System": map[string]string{
+				"OS":   runtime.GOOS,
+				"ARCH": runtime.GOARCH,
+			},
+		},
+	)
+	return cfg
+}
+
+func (p Package) currentPorts(
+	cfg Config,
+	context string,
+) (PackagePortRegistry, error) {
+	retPorts := make(PackagePortRegistry)
+	tmpServices, err := p.services(cfg, context)
+	if err != nil {
+		return nil, err
+	}
+	pkgName := fmt.Sprintf("%s-%s-%s", p.Name, p.Version, context)
 	for _, svc := range tmpServices {
 		shortContainerName := strings.TrimPrefix(svc.ContainerName, pkgName+`-`)
 		tmpPortsContainer := make(ServicePortMap)
@@ -270,12 +327,18 @@ func (p Package) install(
 		}
 		retPorts[shortContainerName] = tmpPortsContainer
 	}
+	return retPorts, nil
+}
+
+func (p Package) renderOutputs(
+	cfg Config,
+	ports PackagePortRegistry,
+) (map[string]string, error) {
 	cfg.Template = cfg.Template.WithVars(
 		map[string]any{
-			"Ports": retPorts,
+			"Ports": ports,
 		},
 	)
-	// Generate outputs
 	retOutputs := make(map[string]string)
 	for _, output := range p.Outputs {
 		// Create key from package name and output name
@@ -292,26 +355,11 @@ func (p Package) install(
 		// Render value template
 		val, err := cfg.Template.Render(output.Value, nil)
 		if err != nil {
-			return "", nil, nil, err
+			return nil, err
 		}
 		retOutputs[key] = val
 	}
-	// Run post-install script
-	if runHooks && p.PostInstallScript != "" {
-		if err := p.runHookScript(cfg, p.PostInstallScript); err != nil {
-			return "", nil, nil, err
-		}
-	}
-	// Render notes and return
-	var retNotes string
-	if p.PostInstallNotes != "" {
-		tmpNotes, err := cfg.Template.Render(p.PostInstallNotes, nil)
-		if err != nil {
-			return "", nil, nil, err
-		}
-		retNotes = tmpNotes
-	}
-	return retNotes, retOutputs, retPorts, nil
+	return retOutputs, nil
 }
 
 func (p Package) uninstall(

--- a/pkgmgr/pkgmgr.go
+++ b/pkgmgr/pkgmgr.go
@@ -117,14 +117,63 @@ func (p *PackageManager) AvailablePackages() []Package {
 }
 
 func (p *PackageManager) Up() error {
-	// Find installed packages
-	installedPackages := p.InstalledPackages()
-	for _, tmpPackage := range installedPackages {
-		err := tmpPackage.Package.startService(p.config, tmpPackage.Context)
+	contextName, _ := p.effectiveContext()
+	stateChanged := false
+	for idx := range p.state.InstalledPackages {
+		installedPkg := &(p.state.InstalledPackages[idx])
+		if installedPkg.Context != contextName {
+			continue
+		}
+		if err := installedPkg.Package.startService(
+			p.config,
+			installedPkg.Context,
+		); err != nil {
+			return err
+		}
+		cfg := installedPkg.Package.withPackageTemplateVars(
+			p.config,
+			installedPkg.Context,
+			installedPkg.Options,
+		)
+		ports, err := installedPkg.Package.currentPorts(
+			cfg,
+			installedPkg.Context,
+		)
 		if err != nil {
 			return err
 		}
+		if err := p.refreshInstalledPackageRuntime(
+			installedPkg,
+			cfg,
+			ports,
+		); err != nil {
+			return err
+		}
+		stateChanged = true
 	}
+	if stateChanged {
+		if err := p.state.Save(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *PackageManager) refreshInstalledPackageRuntime(
+	installedPkg *InstalledPackage,
+	cfg Config,
+	ports PackagePortRegistry,
+) error {
+	outputs, err := installedPkg.Package.renderOutputs(cfg, ports)
+	if err != nil {
+		return err
+	}
+	installedPkg.Outputs = outputs
+	p.setRegisteredPorts(
+		installedPkg.Context,
+		installedPkg.Package.Name,
+		ports,
+	)
 	return nil
 }
 

--- a/pkgmgr/pkgmgr.go
+++ b/pkgmgr/pkgmgr.go
@@ -118,45 +118,48 @@ func (p *PackageManager) AvailablePackages() []Package {
 
 func (p *PackageManager) Up() error {
 	contextName, _ := p.effectiveContext()
-	stateChanged := false
+	var errs []error
 	for idx := range p.state.InstalledPackages {
 		installedPkg := &(p.state.InstalledPackages[idx])
 		if installedPkg.Context != contextName {
 			continue
-		}
-		if err := installedPkg.Package.startService(
-			p.config,
-			installedPkg.Context,
-		); err != nil {
-			return err
 		}
 		cfg := installedPkg.Package.withPackageTemplateVars(
 			p.config,
 			installedPkg.Context,
 			installedPkg.Options,
 		)
+		if err := installedPkg.Package.startService(
+			cfg,
+			installedPkg.Context,
+		); err != nil {
+			errs = append(errs, err)
+			continue
+		}
 		ports, err := installedPkg.Package.currentPorts(
 			cfg,
 			installedPkg.Context,
 		)
 		if err != nil {
-			return err
+			errs = append(errs, err)
+			continue
 		}
 		if err := p.refreshInstalledPackageRuntime(
 			installedPkg,
 			cfg,
 			ports,
 		); err != nil {
-			return err
+			errs = append(errs, err)
+			continue
 		}
-		stateChanged = true
-	}
-	if stateChanged {
+		// Make this package's refreshed outputs available through .Env to
+		// templates rendered for packages processed later in this run.
+		p.initTemplate()
 		if err := p.state.Save(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (p *PackageManager) refreshInstalledPackageRuntime(

--- a/pkgmgr/up_test.go
+++ b/pkgmgr/up_test.go
@@ -14,7 +14,11 @@
 
 package pkgmgr
 
-import "testing"
+import (
+	"io"
+	"log/slog"
+	"testing"
+)
 
 // TestRefreshInstalledPackageRuntimeUpdatesPortOutputs checks that outputs
 // captured from a Docker-managed dynamic port are refreshed after startup.
@@ -68,5 +72,94 @@ func TestRefreshInstalledPackageRuntimeUpdatesPortOutputs(t *testing.T) {
 	}
 	if got, want := pm.state.PortRegistry["default"]["dynamic"]["api"]["8080"], "55964"; got != want {
 		t.Fatalf("unexpected registered port: got %q, want %q", got, want)
+	}
+}
+
+// TestUpRefreshesDependentEnvAndPersistsBeforeLaterFailure checks that package
+// hooks receive package template variables, dependent outputs see refreshed
+// values through .Env, and a later failure does not discard successful work.
+func TestUpRefreshesDependentEnvAndPersistsBeforeLaterFailure(t *testing.T) {
+	cfg := Config{
+		ConfigDir: t.TempDir(),
+		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Template:  NewTemplate(nil),
+	}
+	pm := &PackageManager{
+		config: cfg,
+		state: &State{
+			config:        cfg,
+			ActiveContext: "default",
+			Contexts: map[string]Context{
+				"default": {},
+			},
+			InstalledPackages: []InstalledPackage{
+				{
+					Package: Package{
+						Name:           "successful",
+						Version:        "1.0.0",
+						PreStartScript: `{{ if .Package.Options.enabled }}true{{ else }}false{{ end }}`,
+						Outputs: []PackageOutput{
+							{
+								Name:  "value",
+								Value: "refreshed",
+							},
+						},
+					},
+					Context: "default",
+					Options: map[string]bool{
+						"enabled": true,
+					},
+					Outputs: map[string]string{
+						"SUCCESSFUL_VALUE": "stale",
+					},
+				},
+				{
+					Package: Package{
+						Name:    "dependent",
+						Version: "1.0.0",
+						Outputs: []PackageOutput{
+							{
+								Name:  "value",
+								Value: `{{ .Env.SUCCESSFUL_VALUE }}`,
+							},
+						},
+					},
+					Context: "default",
+					Outputs: map[string]string{
+						"DEPENDENT_VALUE": "stale",
+					},
+				},
+				{
+					Package: Package{
+						Name:           "failing",
+						Version:        "1.0.0",
+						PreStartScript: "exit 1",
+					},
+					Context: "default",
+				},
+			},
+			PortRegistry: make(PortRegistry),
+		},
+	}
+
+	if err := pm.Up(); err == nil {
+		t.Fatal("expected startup error from failing package")
+	}
+	if got, want := pm.state.InstalledPackages[0].Outputs["SUCCESSFUL_VALUE"], "refreshed"; got != want {
+		t.Fatalf("unexpected in-memory output: got %q, want %q", got, want)
+	}
+	if got, want := pm.state.InstalledPackages[1].Outputs["DEPENDENT_VALUE"], "refreshed"; got != want {
+		t.Fatalf("unexpected dependent in-memory output: got %q, want %q", got, want)
+	}
+
+	reloadedState := NewState(cfg)
+	if err := reloadedState.Load(); err != nil {
+		t.Fatalf("failed to reload persisted state: %s", err)
+	}
+	if got, want := reloadedState.InstalledPackages[0].Outputs["SUCCESSFUL_VALUE"], "refreshed"; got != want {
+		t.Fatalf("unexpected persisted output: got %q, want %q", got, want)
+	}
+	if got, want := reloadedState.InstalledPackages[1].Outputs["DEPENDENT_VALUE"], "refreshed"; got != want {
+		t.Fatalf("unexpected dependent persisted output: got %q, want %q", got, want)
 	}
 }

--- a/pkgmgr/up_test.go
+++ b/pkgmgr/up_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkgmgr
+
+import "testing"
+
+// TestRefreshInstalledPackageRuntimeUpdatesPortOutputs checks that outputs
+// captured from a Docker-managed dynamic port are refreshed after startup.
+func TestRefreshInstalledPackageRuntimeUpdatesPortOutputs(t *testing.T) {
+	pkg := Package{
+		Name:    "dynamic",
+		Version: "1.0.0",
+		Outputs: []PackageOutput{
+			{
+				Name:  "port",
+				Value: `{{ index (index .Ports "api") "8080" }}`,
+			},
+		},
+	}
+	installedPkg := InstalledPackage{
+		Package: pkg,
+		Context: "default",
+		Options: map[string]bool{},
+		Outputs: map[string]string{
+			"DYNAMIC_PORT": "55940",
+		},
+	}
+	pm := &PackageManager{
+		config: Config{
+			Template: NewTemplate(nil),
+		},
+		state: &State{
+			PortRegistry: make(PortRegistry),
+		},
+	}
+	cfg := pkg.withPackageTemplateVars(
+		pm.config,
+		installedPkg.Context,
+		installedPkg.Options,
+	)
+	currentPorts := PackagePortRegistry{
+		"api": {
+			"8080": "55964",
+		},
+	}
+
+	if err := pm.refreshInstalledPackageRuntime(
+		&installedPkg,
+		cfg,
+		currentPorts,
+	); err != nil {
+		t.Fatalf("unexpected refresh error: %s", err)
+	}
+	if got, want := installedPkg.Outputs["DYNAMIC_PORT"], "55964"; got != want {
+		t.Fatalf("unexpected refreshed output: got %q, want %q", got, want)
+	}
+	if got, want := pm.state.PortRegistry["default"]["dynamic"]["api"]["8080"], "55964"; got != want {
+		t.Fatalf("unexpected registered port: got %q, want %q", got, want)
+	}
+}

--- a/pkgmgr/up_test.go
+++ b/pkgmgr/up_test.go
@@ -97,7 +97,7 @@ func TestUpRefreshesDependentEnvAndPersistsBeforeLaterFailure(t *testing.T) {
 					Package: Package{
 						Name:           "successful",
 						Version:        "1.0.0",
-						PreStartScript: `{{ if .Package.Options.enabled }}true{{ else }}false{{ end }}`,
+						PreStartScript: `{{ if .Package.Options.enabled }}true{{ else }}exit 1{{ end }}`,
 						Outputs: []PackageOutput{
 							{
 								Name:  "value",

--- a/pkgmgr/up_test.go
+++ b/pkgmgr/up_test.go
@@ -75,10 +75,10 @@ func TestRefreshInstalledPackageRuntimeUpdatesPortOutputs(t *testing.T) {
 	}
 }
 
-// TestUpRefreshesDependentEnvAndPersistsBeforeLaterFailure checks that package
-// hooks receive package template variables, dependent outputs see refreshed
-// values through .Env, and a later failure does not discard successful work.
-func TestUpRefreshesDependentEnvAndPersistsBeforeLaterFailure(t *testing.T) {
+// TestUpContinuesAfterFailureAndPersistsRefreshes checks that package hooks
+// receive package template variables, a package after a startup failure is
+// still refreshed, and dependent outputs see persisted values through .Env.
+func TestUpContinuesAfterFailureAndPersistsRefreshes(t *testing.T) {
 	cfg := Config{
 		ConfigDir: t.TempDir(),
 		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -115,6 +115,14 @@ func TestUpRefreshesDependentEnvAndPersistsBeforeLaterFailure(t *testing.T) {
 				},
 				{
 					Package: Package{
+						Name:           "failing",
+						Version:        "1.0.0",
+						PreStartScript: "exit 1",
+					},
+					Context: "default",
+				},
+				{
+					Package: Package{
 						Name:    "dependent",
 						Version: "1.0.0",
 						Outputs: []PackageOutput{
@@ -129,14 +137,6 @@ func TestUpRefreshesDependentEnvAndPersistsBeforeLaterFailure(t *testing.T) {
 						"DEPENDENT_VALUE": "stale",
 					},
 				},
-				{
-					Package: Package{
-						Name:           "failing",
-						Version:        "1.0.0",
-						PreStartScript: "exit 1",
-					},
-					Context: "default",
-				},
 			},
 			PortRegistry: make(PortRegistry),
 		},
@@ -148,7 +148,7 @@ func TestUpRefreshesDependentEnvAndPersistsBeforeLaterFailure(t *testing.T) {
 	if got, want := pm.state.InstalledPackages[0].Outputs["SUCCESSFUL_VALUE"], "refreshed"; got != want {
 		t.Fatalf("unexpected in-memory output: got %q, want %q", got, want)
 	}
-	if got, want := pm.state.InstalledPackages[1].Outputs["DEPENDENT_VALUE"], "refreshed"; got != want {
+	if got, want := pm.state.InstalledPackages[2].Outputs["DEPENDENT_VALUE"], "refreshed"; got != want {
 		t.Fatalf("unexpected dependent in-memory output: got %q, want %q", got, want)
 	}
 
@@ -159,7 +159,7 @@ func TestUpRefreshesDependentEnvAndPersistsBeforeLaterFailure(t *testing.T) {
 	if got, want := reloadedState.InstalledPackages[0].Outputs["SUCCESSFUL_VALUE"], "refreshed"; got != want {
 		t.Fatalf("unexpected persisted output: got %q, want %q", got, want)
 	}
-	if got, want := reloadedState.InstalledPackages[1].Outputs["DEPENDENT_VALUE"], "refreshed"; got != want {
+	if got, want := reloadedState.InstalledPackages[2].Outputs["DEPENDENT_VALUE"], "refreshed"; got != want {
 		t.Fatalf("unexpected dependent persisted output: got %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
1. Made chanegs to refresh and persist port-based context outputs after starting containers so `context env` matches Docker’s current dynamic ports.
2. Updated `PackageManager.Up()` to inspect actual Docker ports after starting each package.
3. Limited port refreshes to packages in the effective context.
4. Added reusable package template configuration for installation and startup.
5. Extracted Docker port discovery into `currentPorts()` and extracted environment-output generation into `renderOutputs()`.
6. Regenerated installed-package outputs using current ports and updated the context/package port registry after startup.
Persisted refreshed outputs and port mappings to state.
Added a regression test confirming stale outputs and registered ports are replaced with current values.

Closes #261 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes context env outputs after container start so `context env` shows Docker’s current dynamic ports. Applies only to the active context, exposes refreshed outputs to later packages in the same run, and persists updates even if a later package fails. Fixes #261.

- **Bug Fixes**
  - In `Up()`, start each active-context package, inspect current Docker port bindings, and re-render outputs from those ports.
  - Run start hooks with package template vars (including `.Package.Options`); fail fast if options aren’t available.
  - Persist refreshed outputs and port mappings after each package; expose them via `.Env` to later packages in the same run; continue after failures and return a joined error.
  - Add tests for replacing stale dynamic ports, startup continuation/persistence after a package failure, and hook behavior tied to package options.

- **Refactors**
  - Extracted `currentPorts()` and `renderOutputs()` for port discovery and output rendering.
  - Added `withPackageTemplateVars()` and `refreshInstalledPackageRuntime()` to centralize template vars and runtime updates.

<sup>Written for commit 32b1ee29b900fe9e67e95cf3600e97c483dc2be0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up/pull/571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Installed package outputs now reflect current runtime port assignments.
  * Port registrations are refreshed when services are started or updated.
  * Package startup now consistently uses each service’s saved options.
  * State is persisted after runtime changes are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->