### PR TITLE
feat(version): Add version check on command execution

### DIFF
--- a/cmd/cardano-up/main.go
+++ b/cmd/cardano-up/main.go
@@ -36,12 +36,22 @@ var globalFlags = struct {
 	context string
 }{}
 
-func main() {
+// rootCommandDeps carries state out of newRootCommand that main needs after
+// Execute() returns. It's a struct (rather than a bare returned channel) so
+// PersistentPreRun, which runs after newRootCommand has already returned,
+// has somewhere to publish the channel it creates.
+type rootCommandDeps struct {
 	// versionCheckDone is nil unless PersistentPreRun ran (e.g. it doesn't
 	// for --help), in which case it's closed once the background version
 	// check finishes.
-	var versionCheckDone chan struct{}
+	versionCheckDone chan struct{}
+}
 
+// newRootCommand builds the full command tree. It's factored out of main so
+// tests can exercise shouldCheckForNewVersion against the real, production
+// command tree via Find, instead of a hand-built replica that could drift
+// from it.
+func newRootCommand(deps *rootCommandDeps) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use: programName,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
@@ -57,6 +67,16 @@ func main() {
 			)
 			slog.SetDefault(logger)
 
+			// The version-check notice logs to stderr, not stdout: some
+			// commands (e.g. "logs --follow") stream meaningful data to
+			// stdout that callers may parse or pipe, and a notice landing
+			// in the middle of that stream would corrupt it.
+			versionCheckLogger := slog.New(
+				consolelog.NewHandler(os.Stderr, &slog.HandlerOptions{
+					Level: logLevel,
+				}),
+			)
+
 			// Run the version check concurrently with the command itself,
 			// so a slow or unreachable GitHub endpoint doesn't delay the
 			// start of command execution. main waits for it below, after
@@ -68,10 +88,10 @@ func main() {
 			// pre-existing pattern used throughout this CLI; closing that
 			// gap would mean converting every such call site to return an
 			// error instead, which is a much larger, separate change.
-			versionCheckDone = make(chan struct{})
+			deps.versionCheckDone = make(chan struct{})
 			go func() {
-				defer close(versionCheckDone)
-				checkForNewVersion(cmd)
+				defer close(deps.versionCheckDone)
+				checkForNewVersion(cmd, versionCheckLogger)
 			}()
 		},
 	}
@@ -101,9 +121,16 @@ func main() {
 		validateCommand(),
 	)
 
+	return rootCmd
+}
+
+func main() {
+	deps := &rootCommandDeps{}
+	rootCmd := newRootCommand(deps)
+
 	cmdErr := rootCmd.Execute()
-	if versionCheckDone != nil {
-		<-versionCheckDone
+	if deps.versionCheckDone != nil {
+		<-deps.versionCheckDone
 	}
 	if cmdErr != nil {
 		// NOTE: we purposely don't display the error, since cobra will have already displayed it
@@ -147,30 +174,31 @@ func createPackageManager() *pkgmgr.PackageManager {
 }
 
 // checkForNewVersion looks up whether a newer release is available and, if
-// so, logs a warning naming the current and latest versions. It is run in a
-// goroutine from the root command's PersistentPreRun (see main), which waits
-// for it to finish before the process exits; any error here is only logged
-// at debug level and never blocks or fails the command.
-func checkForNewVersion(cmd *cobra.Command) {
-	if version.Version == "" || !shouldCheckForNewVersion(cmd) {
+// so, logs a warning naming the current and latest versions to logger. It is
+// run in a goroutine from the root command's PersistentPreRun (see
+// newRootCommand), which waits for it to finish before the process exits;
+// any error here is only logged at debug level and never blocks or fails
+// the command.
+func checkForNewVersion(cmd *cobra.Command, logger *slog.Logger) {
+	if version.Version == "" || !shouldCheckForNewVersion(cmd.CommandPath()) {
 		return
 	}
 	userCacheDir, err := os.UserCacheDir()
 	if err != nil {
-		slog.Debug("failed to determine cache directory for version check: " + err.Error())
+		logger.Debug("failed to determine cache directory for version check: " + err.Error())
 		return
 	}
 	update, err := version.CheckForUpdate(
 		filepath.Join(userCacheDir, programName),
 	)
 	if err != nil {
-		slog.Debug("failed to check for a newer version: " + err.Error())
+		logger.Debug("failed to check for a newer version: " + err.Error())
 		return
 	}
 	if update == nil {
 		return
 	}
-	slog.Warn(
+	logger.Warn(
 		fmt.Sprintf(
 			"A newer version of %s is available: %s (current: %s). Download it from %s",
 			programName,
@@ -182,14 +210,15 @@ func checkForNewVersion(cmd *cobra.Command) {
 }
 
 // shouldCheckForNewVersion reports whether the version check should run for
-// the given command. It is skipped for "context env" (whose output is
-// meant to be eval'd), "version" (redundant), "help", any "completion"
-// subcommand (whose output is a shell script), and cobra's hidden
-// "__complete"/"__completeNoDesc" commands (invoked by shells on every TAB
-// keypress during interactive completion, so they must never block on a
-// network call or print a warning).
-func shouldCheckForNewVersion(cmd *cobra.Command) bool {
-	commandPath := cmd.CommandPath()
+// the given command path (as returned by cobra.Command.CommandPath()). It's
+// skipped for "context env" (whose output is meant to be eval'd), "version"
+// (redundant), "help", any "completion" subcommand (whose output is a shell
+// script), and cobra's hidden "__complete"/"__completeNoDesc" commands
+// (invoked by shells on every TAB keypress during interactive completion, so
+// they must never block on a network call or print a warning). Taking a
+// plain string, rather than a *cobra.Command, keeps this directly testable
+// against real command paths without needing a live cobra tree.
+func shouldCheckForNewVersion(commandPath string) bool {
 	if commandPath == programName+" context env" ||
 		commandPath == programName+" version" ||
 		commandPath == programName+" help" {

--- a/cmd/cardano-up/main.go
+++ b/cmd/cardano-up/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/blinklabs-io/cardano-up/internal/consolelog"
 	"github.com/blinklabs-io/cardano-up/internal/version"
@@ -29,6 +30,19 @@ import (
 
 const (
 	programName = "cardano-up"
+
+	// noUpdateCheckEnvVar disables the version check entirely when set to
+	// any non-empty value, for offline, air-gapped, or automation/CI
+	// environments that don't want an outbound request to GitHub.
+	noUpdateCheckEnvVar = "NO_UPDATE_CHECK"
+
+	// versionCheckMaxWait bounds how long main will wait for the version
+	// check goroutine below before giving up on it and letting the process
+	// exit anyway. It's set a little above the check's own internal
+	// network timeout as a safety margin, not as the primary bound - it
+	// exists so main's exit is never at the mercy of the check
+	// implementation alone.
+	versionCheckMaxWait = 2 * time.Second
 )
 
 var globalFlags = struct {
@@ -130,7 +144,10 @@ func main() {
 
 	cmdErr := rootCmd.Execute()
 	if deps.versionCheckDone != nil {
-		<-deps.versionCheckDone
+		select {
+		case <-deps.versionCheckDone:
+		case <-time.After(versionCheckMaxWait):
+		}
 	}
 	if cmdErr != nil {
 		// NOTE: we purposely don't display the error, since cobra will have already displayed it
@@ -178,9 +195,13 @@ func createPackageManager() *pkgmgr.PackageManager {
 // run in a goroutine from the root command's PersistentPreRun (see
 // newRootCommand), which waits for it to finish before the process exits;
 // any error here is only logged at debug level and never blocks or fails
-// the command.
+// the command. Set NO_UPDATE_CHECK to any non-empty value to disable this
+// entirely, e.g. for offline or CI use.
 func checkForNewVersion(cmd *cobra.Command, logger *slog.Logger) {
 	if version.Version == "" || !shouldCheckForNewVersion(cmd.CommandPath()) {
+		return
+	}
+	if _, disabled := os.LookupEnv(noUpdateCheckEnvVar); disabled {
 		return
 	}
 	userCacheDir, err := os.UserCacheDir()

--- a/cmd/cardano-up/main.go
+++ b/cmd/cardano-up/main.go
@@ -37,10 +37,10 @@ var globalFlags = struct {
 }{}
 
 func main() {
-	var (
-		versionCheckDone    chan struct{}
-		versionUpdateNotice string
-	)
+	// versionCheckDone is nil unless PersistentPreRun ran (e.g. it doesn't
+	// for --help), in which case it's closed once the background version
+	// check finishes.
+	var versionCheckDone chan struct{}
 
 	rootCmd := &cobra.Command{
 		Use: programName,
@@ -58,16 +58,20 @@ func main() {
 			slog.SetDefault(logger)
 
 			// Run the version check concurrently with the command itself,
-			// so a slow or unreachable GitHub endpoint adds latency only up
-			// to the shortfall versus the command's own runtime instead of
-			// stacking a full extra network round trip in front of every
-			// invocation. The result is collected below, after the command
-			// finishes, so the notice never interleaves with the command's
-			// own output.
+			// so a slow or unreachable GitHub endpoint doesn't delay the
+			// start of command execution. main waits for it below, after
+			// Execute() returns, so it isn't cut off mid-request by the
+			// process exiting the instant the command's own work is done —
+			// Go does not wait for background goroutines to finish on
+			// program exit. This wait is skipped for subcommands that call
+			// os.Exit directly on failure instead of returning an error, a
+			// pre-existing pattern used throughout this CLI; closing that
+			// gap would mean converting every such call site to return an
+			// error instead, which is a much larger, separate change.
 			versionCheckDone = make(chan struct{})
 			go func() {
 				defer close(versionCheckDone)
-				versionUpdateNotice = checkForNewVersion(cmd)
+				checkForNewVersion(cmd)
 			}()
 		},
 	}
@@ -98,12 +102,8 @@ func main() {
 	)
 
 	cmdErr := rootCmd.Execute()
-	// versionCheckDone is nil when PersistentPreRun never ran, e.g. --help.
 	if versionCheckDone != nil {
 		<-versionCheckDone
-	}
-	if versionUpdateNotice != "" {
-		slog.Warn(versionUpdateNotice)
 	}
 	if cmdErr != nil {
 		// NOTE: we purposely don't display the error, since cobra will have already displayed it
@@ -147,36 +147,37 @@ func createPackageManager() *pkgmgr.PackageManager {
 }
 
 // checkForNewVersion looks up whether a newer release is available and, if
-// so, returns a message naming the current and latest versions. It runs in
-// a goroutine started from the root command's PersistentPreRun (see main),
-// so any error here is only logged at debug level and never blocks the
-// command from running; the caller logs the returned message, if any, once
-// the command has finished.
-func checkForNewVersion(cmd *cobra.Command) string {
+// so, logs a warning naming the current and latest versions. It is run in a
+// goroutine from the root command's PersistentPreRun (see main), which waits
+// for it to finish before the process exits; any error here is only logged
+// at debug level and never blocks or fails the command.
+func checkForNewVersion(cmd *cobra.Command) {
 	if version.Version == "" || !shouldCheckForNewVersion(cmd) {
-		return ""
+		return
 	}
 	userCacheDir, err := os.UserCacheDir()
 	if err != nil {
 		slog.Debug("failed to determine cache directory for version check: " + err.Error())
-		return ""
+		return
 	}
 	update, err := version.CheckForUpdate(
 		filepath.Join(userCacheDir, programName),
 	)
 	if err != nil {
 		slog.Debug("failed to check for a newer version: " + err.Error())
-		return ""
+		return
 	}
 	if update == nil {
-		return ""
+		return
 	}
-	return fmt.Sprintf(
-		"A newer version of %s is available: %s (current: %s). Download it from %s",
-		programName,
-		update.LatestVersion,
-		update.CurrentVersion,
-		update.ReleaseURL,
+	slog.Warn(
+		fmt.Sprintf(
+			"A newer version of %s is available: %s (current: %s). Download it from %s",
+			programName,
+			update.LatestVersion,
+			update.CurrentVersion,
+			update.ReleaseURL,
+		),
 	)
 }
 

--- a/cmd/cardano-up/main.go
+++ b/cmd/cardano-up/main.go
@@ -37,6 +37,11 @@ var globalFlags = struct {
 }{}
 
 func main() {
+	var (
+		versionCheckDone    chan struct{}
+		versionUpdateNotice string
+	)
+
 	rootCmd := &cobra.Command{
 		Use: programName,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
@@ -51,7 +56,19 @@ func main() {
 				}),
 			)
 			slog.SetDefault(logger)
-			checkForNewVersion(cmd)
+
+			// Run the version check concurrently with the command itself,
+			// so a slow or unreachable GitHub endpoint adds latency only up
+			// to the shortfall versus the command's own runtime instead of
+			// stacking a full extra network round trip in front of every
+			// invocation. The result is collected below, after the command
+			// finishes, so the notice never interleaves with the command's
+			// own output.
+			versionCheckDone = make(chan struct{})
+			go func() {
+				defer close(versionCheckDone)
+				versionUpdateNotice = checkForNewVersion(cmd)
+			}()
 		},
 	}
 
@@ -80,7 +97,15 @@ func main() {
 		validateCommand(),
 	)
 
-	if err := rootCmd.Execute(); err != nil {
+	cmdErr := rootCmd.Execute()
+	// versionCheckDone is nil when PersistentPreRun never ran, e.g. --help.
+	if versionCheckDone != nil {
+		<-versionCheckDone
+	}
+	if versionUpdateNotice != "" {
+		slog.Warn(versionUpdateNotice)
+	}
+	if cmdErr != nil {
 		// NOTE: we purposely don't display the error, since cobra will have already displayed it
 		os.Exit(1)
 	}
@@ -122,43 +147,46 @@ func createPackageManager() *pkgmgr.PackageManager {
 }
 
 // checkForNewVersion looks up whether a newer release is available and, if
-// so, logs a warning naming the current and latest versions. It is called
-// from the root command's PersistentPreRun, so any error here is only
-// logged at debug level and never blocks the command from running.
-func checkForNewVersion(cmd *cobra.Command) {
+// so, returns a message naming the current and latest versions. It runs in
+// a goroutine started from the root command's PersistentPreRun (see main),
+// so any error here is only logged at debug level and never blocks the
+// command from running; the caller logs the returned message, if any, once
+// the command has finished.
+func checkForNewVersion(cmd *cobra.Command) string {
 	if version.Version == "" || !shouldCheckForNewVersion(cmd) {
-		return
+		return ""
 	}
 	userCacheDir, err := os.UserCacheDir()
 	if err != nil {
 		slog.Debug("failed to determine cache directory for version check: " + err.Error())
-		return
+		return ""
 	}
 	update, err := version.CheckForUpdate(
 		filepath.Join(userCacheDir, programName),
 	)
 	if err != nil {
 		slog.Debug("failed to check for a newer version: " + err.Error())
-		return
+		return ""
 	}
 	if update == nil {
-		return
+		return ""
 	}
-	slog.Warn(
-		fmt.Sprintf(
-			"A newer version of %s is available: %s (current: %s). Download it from %s",
-			programName,
-			update.LatestVersion,
-			update.CurrentVersion,
-			update.ReleaseURL,
-		),
+	return fmt.Sprintf(
+		"A newer version of %s is available: %s (current: %s). Download it from %s",
+		programName,
+		update.LatestVersion,
+		update.CurrentVersion,
+		update.ReleaseURL,
 	)
 }
 
 // shouldCheckForNewVersion reports whether the version check should run for
 // the given command. It is skipped for "context env" (whose output is
-// meant to be eval'd), "version" (redundant), "help", and any "completion"
-// subcommand (whose output is a shell script).
+// meant to be eval'd), "version" (redundant), "help", any "completion"
+// subcommand (whose output is a shell script), and cobra's hidden
+// "__complete"/"__completeNoDesc" commands (invoked by shells on every TAB
+// keypress during interactive completion, so they must never block on a
+// network call or print a warning).
 func shouldCheckForNewVersion(cmd *cobra.Command) bool {
 	commandPath := cmd.CommandPath()
 	if commandPath == programName+" context env" ||
@@ -166,5 +194,6 @@ func shouldCheckForNewVersion(cmd *cobra.Command) bool {
 		commandPath == programName+" help" {
 		return false
 	}
-	return !strings.HasPrefix(commandPath, programName+" completion")
+	return !strings.HasPrefix(commandPath, programName+" completion") &&
+		!strings.HasPrefix(commandPath, programName+" __complete")
 }

--- a/cmd/cardano-up/main.go
+++ b/cmd/cardano-up/main.go
@@ -18,8 +18,11 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/blinklabs-io/cardano-up/internal/consolelog"
+	"github.com/blinklabs-io/cardano-up/internal/version"
 	"github.com/blinklabs-io/cardano-up/pkgmgr"
 	"github.com/spf13/cobra"
 )
@@ -48,6 +51,7 @@ func main() {
 				}),
 			)
 			slog.SetDefault(logger)
+			checkForNewVersion(cmd)
 		},
 	}
 
@@ -115,4 +119,52 @@ func createPackageManager() *pkgmgr.PackageManager {
 		}
 	}
 	return pm
+}
+
+// checkForNewVersion looks up whether a newer release is available and, if
+// so, logs a warning naming the current and latest versions. It is called
+// from the root command's PersistentPreRun, so any error here is only
+// logged at debug level and never blocks the command from running.
+func checkForNewVersion(cmd *cobra.Command) {
+	if version.Version == "" || !shouldCheckForNewVersion(cmd) {
+		return
+	}
+	userCacheDir, err := os.UserCacheDir()
+	if err != nil {
+		slog.Debug("failed to determine cache directory for version check: " + err.Error())
+		return
+	}
+	update, err := version.CheckForUpdate(
+		filepath.Join(userCacheDir, programName),
+	)
+	if err != nil {
+		slog.Debug("failed to check for a newer version: " + err.Error())
+		return
+	}
+	if update == nil {
+		return
+	}
+	slog.Warn(
+		fmt.Sprintf(
+			"A newer version of %s is available: %s (current: %s). Download it from %s",
+			programName,
+			update.LatestVersion,
+			update.CurrentVersion,
+			update.ReleaseURL,
+		),
+	)
+}
+
+// shouldCheckForNewVersion reports whether the version check should run for
+// the given command. It is skipped for "context env" (whose output is
+// meant to be eval'd), "version" (redundant), "help", and any "completion"
+// subcommand (whose output is a shell script).
+func shouldCheckForNewVersion(cmd *cobra.Command) bool {
+	commandPath := cmd.CommandPath()
+	if commandPath == programName+" context env" ||
+		commandPath == programName+" version" ||
+		commandPath == programName+" help" {
+		return false
+	}
+	return !strings.HasPrefix(commandPath, programName+" completion")
 }

--- a/cmd/cardano-up/main.go
+++ b/cmd/cardano-up/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -105,7 +106,7 @@ func newRootCommand(deps *rootCommandDeps) *cobra.Command {
 			deps.versionCheckDone = make(chan struct{})
 			go func() {
 				defer close(deps.versionCheckDone)
-				checkForNewVersion(cmd, versionCheckLogger)
+				checkForNewVersion(cmd, versionCheckLogger, http.DefaultClient)
 			}()
 		},
 	}
@@ -196,8 +197,11 @@ func createPackageManager() *pkgmgr.PackageManager {
 // newRootCommand), which waits for it to finish before the process exits;
 // any error here is only logged at debug level and never blocks or fails
 // the command. Set NO_UPDATE_CHECK to any non-empty value to disable this
-// entirely, e.g. for offline or CI use.
-func checkForNewVersion(cmd *cobra.Command, logger *slog.Logger) {
+// entirely, e.g. for offline or CI use. httpClient is passed through to
+// version.CheckForUpdate explicitly (production code passes
+// http.DefaultClient) so tests can inject a fake one instead of mutating
+// the shared http.DefaultClient.Transport.
+func checkForNewVersion(cmd *cobra.Command, logger *slog.Logger, httpClient *http.Client) {
 	if version.Version == "" || !shouldCheckForNewVersion(cmd.CommandPath()) {
 		return
 	}
@@ -211,6 +215,7 @@ func checkForNewVersion(cmd *cobra.Command, logger *slog.Logger) {
 	}
 	update, err := version.CheckForUpdate(
 		filepath.Join(userCacheDir, programName),
+		httpClient,
 	)
 	if err != nil {
 		logger.Debug("failed to check for a newer version: " + err.Error())

--- a/cmd/cardano-up/main_test.go
+++ b/cmd/cardano-up/main_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	"bytes"
 	"log/slog"
+	"net/http"
 	"testing"
 
 	"github.com/blinklabs-io/cardano-up/internal/consolelog"
@@ -119,12 +120,39 @@ func TestShouldCheckForNewVersion(t *testing.T) {
 // TestCheckForNewVersionRespectsOptOutEnvVar checks that setting
 // NO_UPDATE_CHECK skips the check entirely - before any network call would
 // be made - even for a command and version that would otherwise trigger it.
+// version.CheckForUpdate always issues its request through
+// http.DefaultClient, with no injection point at the public API, so this
+// swaps out its Transport for the duration of the test with one that fails
+// the test outright if it's ever invoked. Only checking for absent log
+// output wouldn't prove this: fetch errors are logged at Debug, which the
+// buffer-backed logger below never surfaces anyway, so a regressed opt-out
+// guard could silently let a real (successful or failed) network call
+// through and this test would still pass.
 func TestCheckForNewVersionRespectsOptOutEnvVar(t *testing.T) {
 	t.Setenv(noUpdateCheckEnvVar, "1")
+
+	// Isolate os.UserCacheDir() to an empty temp dir on every OS. Without
+	// this, a real pre-existing cache file on the machine running the test
+	// (e.g. left over from manually exercising the real binary) would let
+	// checkForNewVersion answer from disk and never reach the network
+	// layer at all, making the Transport guard below moot.
+	cacheDir := t.TempDir()
+	t.Setenv("HOME", cacheDir)
+	t.Setenv("XDG_CACHE_HOME", cacheDir)
+	t.Setenv("LocalAppData", cacheDir)
 
 	originalVersion := version.Version
 	version.Version = "v0.0.1"
 	t.Cleanup(func() { version.Version = originalVersion })
+
+	originalTransport := http.DefaultClient.Transport
+	http.DefaultClient.Transport = roundTripFunc(
+		func(req *http.Request) (*http.Response, error) {
+			t.Fatal("unexpected network call made while NO_UPDATE_CHECK is set")
+			return nil, nil
+		},
+	)
+	t.Cleanup(func() { http.DefaultClient.Transport = originalTransport })
 
 	var buf bytes.Buffer
 	logger := slog.New(consolelog.NewHandler(&buf, nil))
@@ -140,4 +168,10 @@ func TestCheckForNewVersionRespectsOptOutEnvVar(t *testing.T) {
 	if buf.Len() != 0 {
 		t.Fatalf("expected no output when opt-out env var is set, got: %q", buf.String())
 	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }

--- a/cmd/cardano-up/main_test.go
+++ b/cmd/cardano-up/main_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestShouldCheckForNewVersion checks that the version check is skipped for
+// "context env", "version", and any "completion" subcommand, and is run for
+// all other commands.
+func TestShouldCheckForNewVersion(t *testing.T) {
+	rootCmd := &cobra.Command{Use: programName}
+	contextCmd := &cobra.Command{Use: "context"}
+	contextEnvCmd := &cobra.Command{Use: "env"}
+	contextListCmd := &cobra.Command{Use: "list"}
+	contextCmd.AddCommand(contextEnvCmd, contextListCmd)
+	completionCmd := &cobra.Command{Use: "completion"}
+	completionBashCmd := &cobra.Command{Use: "bash"}
+	completionCmd.AddCommand(completionBashCmd)
+	versionCmd := &cobra.Command{Use: "version"}
+	upCmd := &cobra.Command{Use: "up"}
+	rootCmd.AddCommand(contextCmd, completionCmd, versionCmd, upCmd)
+
+	tests := []struct {
+		name string
+		cmd  *cobra.Command
+		want bool
+	}{
+		{
+			name: "context env is skipped",
+			cmd:  contextEnvCmd,
+			want: false,
+		},
+		{
+			name: "completion is skipped",
+			cmd:  completionBashCmd,
+			want: false,
+		},
+		{
+			name: "version is skipped",
+			cmd:  versionCmd,
+			want: false,
+		},
+		{
+			name: "context list is checked",
+			cmd:  contextListCmd,
+			want: true,
+		},
+		{
+			name: "up is checked",
+			cmd:  upCmd,
+			want: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := shouldCheckForNewVersion(test.cmd); got != test.want {
+				t.Fatalf("unexpected check decision: got %t, want %t", got, test.want)
+			}
+		})
+	}
+}

--- a/cmd/cardano-up/main_test.go
+++ b/cmd/cardano-up/main_test.go
@@ -120,14 +120,15 @@ func TestShouldCheckForNewVersion(t *testing.T) {
 // TestCheckForNewVersionRespectsOptOutEnvVar checks that setting
 // NO_UPDATE_CHECK skips the check entirely - before any network call would
 // be made - even for a command and version that would otherwise trigger it.
-// version.CheckForUpdate always issues its request through
-// http.DefaultClient, with no injection point at the public API, so this
-// swaps out its Transport for the duration of the test with one that fails
-// the test outright if it's ever invoked. Only checking for absent log
-// output wouldn't prove this: fetch errors are logged at Debug, which the
-// buffer-backed logger below never surfaces anyway, so a regressed opt-out
-// guard could silently let a real (successful or failed) network call
-// through and this test would still pass.
+// checkForNewVersion takes an *http.Client explicitly, so this passes one
+// backed by a RoundTripper that fails the test outright if it's ever
+// invoked, rather than mutating the shared http.DefaultClient.Transport
+// (which would be fragile under parallel tests or any other code path
+// using the default client during this window). Only checking for absent
+// log output wouldn't prove this on its own: fetch errors are logged at
+// Debug, which the buffer-backed logger below never surfaces anyway, so a
+// regressed opt-out guard could silently let a real (successful or failed)
+// network call through and this test would still pass.
 func TestCheckForNewVersionRespectsOptOutEnvVar(t *testing.T) {
 	t.Setenv(noUpdateCheckEnvVar, "1")
 
@@ -135,7 +136,7 @@ func TestCheckForNewVersionRespectsOptOutEnvVar(t *testing.T) {
 	// this, a real pre-existing cache file on the machine running the test
 	// (e.g. left over from manually exercising the real binary) would let
 	// checkForNewVersion answer from disk and never reach the network
-	// layer at all, making the Transport guard below moot.
+	// layer at all, making the injected client below moot.
 	cacheDir := t.TempDir()
 	t.Setenv("HOME", cacheDir)
 	t.Setenv("XDG_CACHE_HOME", cacheDir)
@@ -145,14 +146,14 @@ func TestCheckForNewVersionRespectsOptOutEnvVar(t *testing.T) {
 	version.Version = "v0.0.1"
 	t.Cleanup(func() { version.Version = originalVersion })
 
-	originalTransport := http.DefaultClient.Transport
-	http.DefaultClient.Transport = roundTripFunc(
-		func(req *http.Request) (*http.Response, error) {
-			t.Fatal("unexpected network call made while NO_UPDATE_CHECK is set")
-			return nil, nil
-		},
-	)
-	t.Cleanup(func() { http.DefaultClient.Transport = originalTransport })
+	failingClient := &http.Client{
+		Transport: roundTripFunc(
+			func(req *http.Request) (*http.Response, error) {
+				t.Fatal("unexpected network call made while NO_UPDATE_CHECK is set")
+				return nil, nil
+			},
+		),
+	}
 
 	var buf bytes.Buffer
 	logger := slog.New(consolelog.NewHandler(&buf, nil))
@@ -163,7 +164,7 @@ func TestCheckForNewVersionRespectsOptOutEnvVar(t *testing.T) {
 		t.Fatalf("failed to resolve command: %s", err)
 	}
 
-	checkForNewVersion(cmd, logger)
+	checkForNewVersion(cmd, logger, failingClient)
 
 	if buf.Len() != 0 {
 		t.Fatalf("expected no output when opt-out env var is set, got: %q", buf.String())

--- a/cmd/cardano-up/main_test.go
+++ b/cmd/cardano-up/main_test.go
@@ -15,8 +15,12 @@
 package main
 
 import (
+	"bytes"
+	"log/slog"
 	"testing"
 
+	"github.com/blinklabs-io/cardano-up/internal/consolelog"
+	"github.com/blinklabs-io/cardano-up/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -80,12 +84,60 @@ func TestShouldCheckForNewVersion(t *testing.T) {
 
 	// cobra only registers "__complete" (aliased as "__completeNoDesc")
 	// inside Execute() itself, with no exported way to add it without
-	// actually running the command tree, so this case is checked directly
-	// against the path cobra's own exported constant would produce.
-	t.Run("hidden shell completion request is skipped", func(t *testing.T) {
-		commandPath := programName + " " + cobra.ShellCompRequestCmd
-		if got := shouldCheckForNewVersion(commandPath); got != false {
-			t.Fatalf("unexpected check decision: got %t, want false", got)
-		}
-	})
+	// actually running the command tree, so these cases are checked
+	// directly against the paths cobra's own exported constants would
+	// produce. "__completeNoDesc" is an alias, not a separate command, so a
+	// real invocation's CommandPath() is always "... __complete" regardless
+	// of which name the shell invoked it as - shouldCheckForNewVersion only
+	// ever sees that one form in production. The second case below still
+	// pins down real, independent coverage: it confirms the skip is a
+	// prefix match broad enough to also catch "__completeNoDesc" directly,
+	// not narrowed to an exact match on "__complete" alone.
+	hiddenCompletionCases := []struct {
+		name       string
+		commandArg string
+	}{
+		{
+			name:       "__complete is skipped",
+			commandArg: cobra.ShellCompRequestCmd,
+		},
+		{
+			name:       "__completeNoDesc is skipped",
+			commandArg: cobra.ShellCompNoDescRequestCmd,
+		},
+	}
+	for _, test := range hiddenCompletionCases {
+		t.Run(test.name, func(t *testing.T) {
+			commandPath := programName + " " + test.commandArg
+			if got := shouldCheckForNewVersion(commandPath); got != false {
+				t.Fatalf("unexpected check decision: got %t, want false", got)
+			}
+		})
+	}
+}
+
+// TestCheckForNewVersionRespectsOptOutEnvVar checks that setting
+// NO_UPDATE_CHECK skips the check entirely - before any network call would
+// be made - even for a command and version that would otherwise trigger it.
+func TestCheckForNewVersionRespectsOptOutEnvVar(t *testing.T) {
+	t.Setenv(noUpdateCheckEnvVar, "1")
+
+	originalVersion := version.Version
+	version.Version = "v0.0.1"
+	t.Cleanup(func() { version.Version = originalVersion })
+
+	var buf bytes.Buffer
+	logger := slog.New(consolelog.NewHandler(&buf, nil))
+
+	rootCmd := newRootCommand(&rootCommandDeps{})
+	cmd, _, err := rootCmd.Find([]string{"list"})
+	if err != nil {
+		t.Fatalf("failed to resolve command: %s", err)
+	}
+
+	checkForNewVersion(cmd, logger)
+
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output when opt-out env var is set, got: %q", buf.String())
+	}
 }

--- a/cmd/cardano-up/main_test.go
+++ b/cmd/cardano-up/main_test.go
@@ -21,8 +21,8 @@ import (
 )
 
 // TestShouldCheckForNewVersion checks that the version check is skipped for
-// "context env", "version", and any "completion" subcommand, and is run for
-// all other commands.
+// "context env", "version", any "completion" subcommand, and cobra's hidden
+// "__complete" shell-completion command, and is run for all other commands.
 func TestShouldCheckForNewVersion(t *testing.T) {
 	rootCmd := &cobra.Command{Use: programName}
 	contextCmd := &cobra.Command{Use: "context"}
@@ -34,7 +34,14 @@ func TestShouldCheckForNewVersion(t *testing.T) {
 	completionCmd.AddCommand(completionBashCmd)
 	versionCmd := &cobra.Command{Use: "version"}
 	upCmd := &cobra.Command{Use: "up"}
-	rootCmd.AddCommand(contextCmd, completionCmd, versionCmd, upCmd)
+	// Mirrors how cobra itself registers the hidden completion-request
+	// command during Execute(): a single "__complete" command aliased as
+	// "__completeNoDesc", both invoked by shells on every TAB keypress.
+	shellCompCmd := &cobra.Command{
+		Use:     cobra.ShellCompRequestCmd,
+		Aliases: []string{cobra.ShellCompNoDescRequestCmd},
+	}
+	rootCmd.AddCommand(contextCmd, completionCmd, versionCmd, upCmd, shellCompCmd)
 
 	tests := []struct {
 		name string
@@ -54,6 +61,11 @@ func TestShouldCheckForNewVersion(t *testing.T) {
 		{
 			name: "version is skipped",
 			cmd:  versionCmd,
+			want: false,
+		},
+		{
+			name: "hidden shell completion request is skipped",
+			cmd:  shellCompCmd,
 			want: false,
 		},
 		{

--- a/cmd/cardano-up/main_test.go
+++ b/cmd/cardano-up/main_test.go
@@ -23,68 +23,69 @@ import (
 // TestShouldCheckForNewVersion checks that the version check is skipped for
 // "context env", "version", any "completion" subcommand, and cobra's hidden
 // "__complete" shell-completion command, and is run for all other commands.
+// It resolves real subcommand paths from the production command tree built
+// by newRootCommand, rather than a hand-built replica, so the coverage
+// tracks the actual command names rather than a copy that could drift from
+// them.
 func TestShouldCheckForNewVersion(t *testing.T) {
-	rootCmd := &cobra.Command{Use: programName}
-	contextCmd := &cobra.Command{Use: "context"}
-	contextEnvCmd := &cobra.Command{Use: "env"}
-	contextListCmd := &cobra.Command{Use: "list"}
-	contextCmd.AddCommand(contextEnvCmd, contextListCmd)
-	completionCmd := &cobra.Command{Use: "completion"}
-	completionBashCmd := &cobra.Command{Use: "bash"}
-	completionCmd.AddCommand(completionBashCmd)
-	versionCmd := &cobra.Command{Use: "version"}
-	upCmd := &cobra.Command{Use: "up"}
-	// Mirrors how cobra itself registers the hidden completion-request
-	// command during Execute(): a single "__complete" command aliased as
-	// "__completeNoDesc", both invoked by shells on every TAB keypress.
-	shellCompCmd := &cobra.Command{
-		Use:     cobra.ShellCompRequestCmd,
-		Aliases: []string{cobra.ShellCompNoDescRequestCmd},
-	}
-	rootCmd.AddCommand(contextCmd, completionCmd, versionCmd, upCmd, shellCompCmd)
+	rootCmd := newRootCommand(&rootCommandDeps{})
+	// cobra only registers the default "completion" command inside
+	// Execute(); call the exported initializer directly so Find can resolve
+	// it without actually executing the command tree.
+	rootCmd.InitDefaultCompletionCmd()
 
 	tests := []struct {
 		name string
-		cmd  *cobra.Command
+		args []string
 		want bool
 	}{
 		{
 			name: "context env is skipped",
-			cmd:  contextEnvCmd,
+			args: []string{"context", "env"},
 			want: false,
 		},
 		{
 			name: "completion is skipped",
-			cmd:  completionBashCmd,
+			args: []string{"completion", "bash"},
 			want: false,
 		},
 		{
 			name: "version is skipped",
-			cmd:  versionCmd,
-			want: false,
-		},
-		{
-			name: "hidden shell completion request is skipped",
-			cmd:  shellCompCmd,
+			args: []string{"version"},
 			want: false,
 		},
 		{
 			name: "context list is checked",
-			cmd:  contextListCmd,
+			args: []string{"context", "list"},
 			want: true,
 		},
 		{
 			name: "up is checked",
-			cmd:  upCmd,
+			args: []string{"up"},
 			want: true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if got := shouldCheckForNewVersion(test.cmd); got != test.want {
+			cmd, _, err := rootCmd.Find(test.args)
+			if err != nil {
+				t.Fatalf("failed to resolve command %v: %s", test.args, err)
+			}
+			if got := shouldCheckForNewVersion(cmd.CommandPath()); got != test.want {
 				t.Fatalf("unexpected check decision: got %t, want %t", got, test.want)
 			}
 		})
 	}
+
+	// cobra only registers "__complete" (aliased as "__completeNoDesc")
+	// inside Execute() itself, with no exported way to add it without
+	// actually running the command tree, so this case is checked directly
+	// against the path cobra's own exported constant would produce.
+	t.Run("hidden shell completion request is skipped", func(t *testing.T) {
+		commandPath := programName + " " + cobra.ShellCompRequestCmd
+		if got := shouldCheckForNewVersion(commandPath); got != false {
+			t.Fatalf("unexpected check decision: got %t, want false", got)
+		}
+	})
 }

--- a/internal/version/check.go
+++ b/internal/version/check.go
@@ -54,7 +54,11 @@ type releaseInfo struct {
 
 // CheckForUpdate returns release information when the running release is
 // older than the latest published release. Development builds are skipped.
-func CheckForUpdate(cacheDir string) (*Update, error) {
+// httpClient makes the request; callers should normally pass
+// http.DefaultClient. Taking it explicitly, rather than defaulting
+// internally, gives callers an injection point for testing without needing
+// to mutate the shared http.DefaultClient.Transport.
+func CheckForUpdate(cacheDir string, httpClient *http.Client) (*Update, error) {
 	if Version == "" {
 		return nil, nil
 	}
@@ -68,7 +72,7 @@ func CheckForUpdate(cacheDir string) (*Update, error) {
 		Version,
 		cacheDir,
 		latestReleaseURL,
-		http.DefaultClient,
+		httpClient,
 		time.Now(),
 	)
 }

--- a/internal/version/check.go
+++ b/internal/version/check.go
@@ -238,5 +238,9 @@ func saveCachedRelease(cacheDir string, release releaseInfo) error {
 		os.Remove(tmpPath)
 		return err
 	}
-	return os.Rename(tmpPath, filepath.Join(cacheDir, versionCacheFile))
+	if err := os.Rename(tmpPath, filepath.Join(cacheDir, versionCacheFile)); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return nil
 }

--- a/internal/version/check.go
+++ b/internal/version/check.go
@@ -93,9 +93,9 @@ func checkForUpdate(
 		return nil, fmt.Errorf("parse current version: %w", err)
 	}
 
-	release, err := loadCachedRelease(cacheDir, now)
+	release, latest, err := loadCachedRelease(cacheDir, now)
 	if err != nil || release == nil {
-		release, err = fetchLatestRelease(ctx, releaseURL, httpClient)
+		release, latest, err = fetchLatestRelease(ctx, releaseURL, httpClient)
 		if err != nil {
 			return nil, err
 		}
@@ -104,10 +104,6 @@ func checkForUpdate(
 		_ = saveCachedRelease(cacheDir, *release)
 	}
 
-	latest, err := hashicorpversion.NewVersion(release.TagName)
-	if err != nil {
-		return nil, fmt.Errorf("parse latest version: %w", err)
-	}
 	if !latest.GreaterThan(current) {
 		return nil, nil
 	}
@@ -119,41 +115,47 @@ func checkForUpdate(
 }
 
 // loadCachedRelease reads the cached release info from cacheDir. It returns
-// a nil release (with no error) when the cache file is missing or older
-// than versionCacheTTL, signaling the caller to fetch a fresh copy.
+// a nil release (with no error) when the cached copy is older than
+// versionCacheTTL, and an error when the file is missing, unreadable, or
+// invalid, either of which signals the caller to fetch a fresh copy. The
+// returned version is release.TagName already parsed by validateRelease, so
+// callers never need to parse it a second time.
 func loadCachedRelease(
 	cacheDir string,
 	now time.Time,
-) (*releaseInfo, error) {
+) (*releaseInfo, *hashicorpversion.Version, error) {
 	cachePath := filepath.Join(cacheDir, versionCacheFile)
 	stat, err := os.Stat(cachePath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if stat.ModTime().Before(now.Add(-versionCacheTTL)) {
-		return nil, nil
+		return nil, nil, nil
 	}
 	content, err := os.ReadFile(cachePath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	var release releaseInfo
 	if err := json.Unmarshal(content, &release); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	if err := validateRelease(release); err != nil {
-		return nil, fmt.Errorf("invalid cached release: %w", err)
+	parsed, err := validateRelease(release)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid cached release: %w", err)
 	}
-	return &release, nil
+	return &release, parsed, nil
 }
 
 // fetchLatestRelease calls the GitHub releases API and returns the parsed
-// release info for the latest published release.
+// release info for the latest published release, along with release.TagName
+// already parsed by validateRelease so callers never need to parse it a
+// second time.
 func fetchLatestRelease(
 	ctx context.Context,
 	releaseURL string,
 	httpClient *http.Client,
-) (*releaseInfo, error) {
+) (*releaseInfo, *hashicorpversion.Version, error) {
 	req, err := http.NewRequestWithContext(
 		ctx,
 		http.MethodGet,
@@ -161,50 +163,52 @@ func fetchLatestRelease(
 		nil,
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("X-GitHub-Api-Version", "2026-03-10")
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if resp == nil {
-		return nil, errors.New("empty latest release response")
+		return nil, nil, errors.New("empty latest release response")
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		_, _ = io.Copy(io.Discard, resp.Body)
-		return nil, fmt.Errorf(
+		return nil, nil, fmt.Errorf(
 			"latest release request returned %s",
 			resp.Status,
 		)
 	}
 	var release releaseInfo
 	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	if err := validateRelease(release); err != nil {
-		return nil, fmt.Errorf("invalid latest release: %w", err)
+	parsed, err := validateRelease(release)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid latest release: %w", err)
 	}
-	return &release, nil
+	return &release, parsed, nil
 }
 
 // validateRelease checks that a releaseInfo has the fields needed to build
-// an Update, whether it came from the cache or a fresh API response. It
-// parses TagName as a version so a malformed tag is rejected here, before a
-// fetched release is cached or a cached release is reused.
-func validateRelease(release releaseInfo) error {
+// an Update, whether it came from the cache or a fresh API response, and
+// returns TagName parsed as a version. A malformed tag is rejected here,
+// before a fetched release is cached or a cached release is reused.
+func validateRelease(release releaseInfo) (*hashicorpversion.Version, error) {
 	if release.TagName == "" {
-		return errors.New("missing tag name")
+		return nil, errors.New("missing tag name")
 	}
 	if release.HTMLURL == "" {
-		return errors.New("missing release URL")
+		return nil, errors.New("missing release URL")
 	}
-	if _, err := hashicorpversion.NewVersion(release.TagName); err != nil {
-		return fmt.Errorf("invalid tag name %q: %w", release.TagName, err)
+	parsed, err := hashicorpversion.NewVersion(release.TagName)
+	if err != nil {
+		return nil, fmt.Errorf("invalid tag name %q: %w", release.TagName, err)
 	}
-	return nil
+	return parsed, nil
 }
 
 // saveCachedRelease writes release to cacheDir so the next check within

--- a/internal/version/check.go
+++ b/internal/version/check.go
@@ -1,0 +1,210 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	hashicorpversion "github.com/hashicorp/go-version"
+)
+
+const (
+	latestReleaseURL    = "https://api.github.com/repos/blinklabs-io/cardano-up/releases/latest"
+	versionCacheFile    = "latest_version.json"
+	versionCacheTTL     = 24 * time.Hour
+	versionCheckTimeout = 3 * time.Second
+)
+
+type Update struct {
+	CurrentVersion string
+	LatestVersion  string
+	ReleaseURL     string
+}
+
+type releaseInfo struct {
+	TagName string `json:"tag_name"`
+	HTMLURL string `json:"html_url"`
+}
+
+// CheckForUpdate returns release information when the running release is
+// older than the latest published release. Development builds are skipped.
+func CheckForUpdate(cacheDir string) (*Update, error) {
+	if Version == "" {
+		return nil, nil
+	}
+	ctx, cancel := context.WithTimeout(
+		context.Background(),
+		versionCheckTimeout,
+	)
+	defer cancel()
+	return checkForUpdate(
+		ctx,
+		Version,
+		cacheDir,
+		latestReleaseURL,
+		http.DefaultClient,
+		time.Now(),
+	)
+}
+
+// checkForUpdate contains the actual update-check logic behind
+// CheckForUpdate, with the current time and HTTP client passed in so tests
+// can control caching and avoid real network calls.
+func checkForUpdate(
+	ctx context.Context,
+	currentVersion string,
+	cacheDir string,
+	releaseURL string,
+	httpClient *http.Client,
+	now time.Time,
+) (*Update, error) {
+	current, err := hashicorpversion.NewVersion(currentVersion)
+	if err != nil {
+		return nil, fmt.Errorf("parse current version: %w", err)
+	}
+
+	release, err := loadCachedRelease(cacheDir, now)
+	if err != nil || release == nil {
+		release, err = fetchLatestRelease(ctx, releaseURL, httpClient)
+		if err != nil {
+			return nil, err
+		}
+		// Caching is best-effort: a read-only cache directory must not
+		// suppress an otherwise valid update notice.
+		_ = saveCachedRelease(cacheDir, *release)
+	}
+
+	latest, err := hashicorpversion.NewVersion(release.TagName)
+	if err != nil {
+		return nil, fmt.Errorf("parse latest version: %w", err)
+	}
+	if !latest.GreaterThan(current) {
+		return nil, nil
+	}
+	return &Update{
+		CurrentVersion: currentVersion,
+		LatestVersion:  release.TagName,
+		ReleaseURL:     release.HTMLURL,
+	}, nil
+}
+
+// loadCachedRelease reads the cached release info from cacheDir. It returns
+// a nil release (with no error) when the cache file is missing or older
+// than versionCacheTTL, signaling the caller to fetch a fresh copy.
+func loadCachedRelease(
+	cacheDir string,
+	now time.Time,
+) (*releaseInfo, error) {
+	cachePath := filepath.Join(cacheDir, versionCacheFile)
+	stat, err := os.Stat(cachePath)
+	if err != nil {
+		return nil, err
+	}
+	if stat.ModTime().Before(now.Add(-versionCacheTTL)) {
+		return nil, nil
+	}
+	content, err := os.ReadFile(cachePath)
+	if err != nil {
+		return nil, err
+	}
+	var release releaseInfo
+	if err := json.Unmarshal(content, &release); err != nil {
+		return nil, err
+	}
+	if err := validateRelease(release); err != nil {
+		return nil, fmt.Errorf("invalid cached release: %w", err)
+	}
+	return &release, nil
+}
+
+// fetchLatestRelease calls the GitHub releases API and returns the parsed
+// release info for the latest published release.
+func fetchLatestRelease(
+	ctx context.Context,
+	releaseURL string,
+	httpClient *http.Client,
+) (*releaseInfo, error) {
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		releaseURL,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2026-03-10")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, errors.New("empty latest release response")
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, fmt.Errorf(
+			"latest release request returned %s",
+			resp.Status,
+		)
+	}
+	var release releaseInfo
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, err
+	}
+	if err := validateRelease(release); err != nil {
+		return nil, fmt.Errorf("invalid latest release: %w", err)
+	}
+	return &release, nil
+}
+
+// validateRelease checks that a releaseInfo has the fields needed to build
+// an Update, whether it came from the cache or a fresh API response.
+func validateRelease(release releaseInfo) error {
+	if release.TagName == "" {
+		return errors.New("missing tag name")
+	}
+	if release.HTMLURL == "" {
+		return errors.New("missing release URL")
+	}
+	return nil
+}
+
+// saveCachedRelease writes release to cacheDir so the next check within
+// versionCacheTTL can skip the network call.
+func saveCachedRelease(cacheDir string, release releaseInfo) error {
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		return err
+	}
+	content, err := json.Marshal(release)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(
+		filepath.Join(cacheDir, versionCacheFile),
+		content,
+		0o600,
+	)
+}

--- a/internal/version/check.go
+++ b/internal/version/check.go
@@ -181,13 +181,18 @@ func fetchLatestRelease(
 }
 
 // validateRelease checks that a releaseInfo has the fields needed to build
-// an Update, whether it came from the cache or a fresh API response.
+// an Update, whether it came from the cache or a fresh API response. It
+// parses TagName as a version so a malformed tag is rejected here, before a
+// fetched release is cached or a cached release is reused.
 func validateRelease(release releaseInfo) error {
 	if release.TagName == "" {
 		return errors.New("missing tag name")
 	}
 	if release.HTMLURL == "" {
 		return errors.New("missing release URL")
+	}
+	if _, err := hashicorpversion.NewVersion(release.TagName); err != nil {
+		return fmt.Errorf("invalid tag name %q: %w", release.TagName, err)
 	}
 	return nil
 }

--- a/internal/version/check.go
+++ b/internal/version/check.go
@@ -29,10 +29,16 @@ import (
 )
 
 const (
-	latestReleaseURL    = "https://api.github.com/repos/blinklabs-io/cardano-up/releases/latest"
-	versionCacheFile    = "latest_version.json"
-	versionCacheTTL     = 24 * time.Hour
-	versionCheckTimeout = 3 * time.Second
+	latestReleaseURL = "https://api.github.com/repos/blinklabs-io/cardano-up/releases/latest"
+	versionCacheFile = "latest_version.json"
+	versionCacheTTL  = 24 * time.Hour
+	// versionCheckTimeout bounds the worst case: main waits for this check to
+	// finish before the process exits (see cmd/cardano-up/main.go), so on an
+	// unresponsive endpoint this is the maximum added delay to a command
+	// that would otherwise return faster. Kept well above real-world GitHub
+	// API latency (well under 1s in practice) so a normal, working request
+	// isn't cut short.
+	versionCheckTimeout = 1500 * time.Millisecond
 )
 
 type Update struct {
@@ -198,7 +204,10 @@ func validateRelease(release releaseInfo) error {
 }
 
 // saveCachedRelease writes release to cacheDir so the next check within
-// versionCacheTTL can skip the network call.
+// versionCacheTTL can skip the network call. It writes to a temporary file
+// and renames it into place, since the process runs this from a background
+// goroutine that can be cut off by an os.Exit elsewhere at any moment — a
+// direct write could otherwise leave a truncated cache file on disk.
 func saveCachedRelease(cacheDir string, release releaseInfo) error {
 	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
 		return err
@@ -207,9 +216,23 @@ func saveCachedRelease(cacheDir string, release releaseInfo) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(
-		filepath.Join(cacheDir, versionCacheFile),
-		content,
-		0o600,
-	)
+	tmpFile, err := os.CreateTemp(cacheDir, versionCacheFile+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmpFile.Name()
+	if _, err := tmpFile.Write(content); err != nil {
+		tmpFile.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, filepath.Join(cacheDir, versionCacheFile))
 }

--- a/internal/version/check_test.go
+++ b/internal/version/check_test.go
@@ -177,6 +177,86 @@ func TestCheckForUpdateReplacesInvalidCache(t *testing.T) {
 	}
 }
 
+// TestCheckForUpdateReplacesMalformedCachedTag checks that a cache file with
+// well-formed JSON but an unparseable tag_name is treated the same as an
+// invalid cache: it's ignored and replaced with a fresh request, rather than
+// being reused as-is or surfacing a parse error to the caller.
+func TestCheckForUpdateReplacesMalformedCachedTag(t *testing.T) {
+	cacheDir := t.TempDir()
+	cachePath := filepath.Join(cacheDir, versionCacheFile)
+	if err := os.WriteFile(
+		cachePath,
+		[]byte(`{"tag_name":"not-a-version","html_url":"https://example.test/bad"}`),
+		0o600,
+	); err != nil {
+		t.Fatalf("failed to write malformed test cache: %s", err)
+	}
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			requestCount++
+			_, _ = w.Write([]byte(
+				`{"tag_name":"v1.3.0","html_url":"https://example.test/v1.3.0"}`,
+			))
+		},
+	))
+	defer server.Close()
+
+	update, err := checkForUpdate(
+		context.Background(),
+		"v1.2.0",
+		cacheDir,
+		server.URL,
+		server.Client(),
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected version check error: %s", err)
+	}
+	if update == nil || update.LatestVersion != "v1.3.0" {
+		t.Fatalf("unexpected update after malformed cached tag: %#v", update)
+	}
+	if requestCount != 1 {
+		t.Fatalf("malformed cached tag should be replaced, got %d requests", requestCount)
+	}
+}
+
+// TestCheckForUpdateRejectsMalformedFetchedTag checks that a release fetched
+// from the API with an unparseable tag_name is rejected outright, and that
+// it is never written to the cache — otherwise a bad response would get
+// reused for a full versionCacheTTL instead of being retried on the next
+// invocation.
+func TestCheckForUpdateRejectsMalformedFetchedTag(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(
+				`{"tag_name":"not-a-version","html_url":"https://example.test/bad"}`,
+			))
+		},
+	))
+	defer server.Close()
+
+	cacheDir := t.TempDir()
+	_, err := checkForUpdate(
+		context.Background(),
+		"v1.2.0",
+		cacheDir,
+		server.URL,
+		server.Client(),
+		time.Now(),
+	)
+	if err == nil {
+		t.Fatal("expected an error for a malformed fetched tag")
+	}
+
+	if _, statErr := os.Stat(filepath.Join(cacheDir, versionCacheFile)); statErr == nil {
+		t.Fatal("malformed release should not have been cached")
+	} else if !os.IsNotExist(statErr) {
+		t.Fatalf("unexpected error checking cache file: %s", statErr)
+	}
+}
+
 // TestCheckForUpdateReturnsNilForCurrentVersion checks that no update is
 // reported when the running version matches the latest published release.
 func TestCheckForUpdateReturnsNilForCurrentVersion(t *testing.T) {

--- a/internal/version/check_test.go
+++ b/internal/version/check_test.go
@@ -1,0 +1,254 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestCheckForUpdateFetchesAndCachesLatestRelease checks that a first call
+// hits the GitHub API and writes a cache file, and that a second call within
+// the TTL reuses the cache instead of making another request.
+func TestCheckForUpdateFetchesAndCachesLatestRelease(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			requestCount++
+			if got, want := r.Header.Get("Accept"), "application/vnd.github+json"; got != want {
+				t.Errorf("unexpected Accept header: got %q, want %q", got, want)
+			}
+			if got, want := r.Header.Get("X-GitHub-Api-Version"), "2026-03-10"; got != want {
+				t.Errorf("unexpected API version header: got %q, want %q", got, want)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(
+				`{"tag_name":"v1.2.0","html_url":"https://example.test/v1.2.0"}`,
+			))
+		},
+	))
+	defer server.Close()
+
+	cacheDir := t.TempDir()
+	now := time.Now()
+	update, err := checkForUpdate(
+		context.Background(),
+		"v1.1.0",
+		cacheDir,
+		server.URL,
+		server.Client(),
+		now,
+	)
+	if err != nil {
+		t.Fatalf("unexpected version check error: %s", err)
+	}
+	if update == nil {
+		t.Fatal("expected an available update")
+	}
+	if got, want := update.LatestVersion, "v1.2.0"; got != want {
+		t.Fatalf("unexpected latest version: got %q, want %q", got, want)
+	}
+	if requestCount != 1 {
+		t.Fatalf("unexpected request count: got %d, want 1", requestCount)
+	}
+
+	update, err = checkForUpdate(
+		context.Background(),
+		"v1.1.0",
+		cacheDir,
+		server.URL,
+		server.Client(),
+		now.Add(time.Hour),
+	)
+	if err != nil {
+		t.Fatalf("unexpected cached version check error: %s", err)
+	}
+	if update == nil || update.LatestVersion != "v1.2.0" {
+		t.Fatalf("unexpected cached update: %#v", update)
+	}
+	if requestCount != 1 {
+		t.Fatalf("fresh cache should avoid another request, got %d requests", requestCount)
+	}
+}
+
+// TestCheckForUpdateRefreshesStaleCache checks that a cache file older than
+// the TTL is treated as expired and triggers a fresh request instead of
+// being reused.
+func TestCheckForUpdateRefreshesStaleCache(t *testing.T) {
+	cacheDir := t.TempDir()
+	cachePath := filepath.Join(cacheDir, versionCacheFile)
+	if err := os.WriteFile(
+		cachePath,
+		[]byte(`{"tag_name":"v1.1.0","html_url":"https://example.test/v1.1.0"}`),
+		0o600,
+	); err != nil {
+		t.Fatalf("failed to write test cache: %s", err)
+	}
+	oldTime := time.Now().Add(-versionCacheTTL - time.Hour)
+	if err := os.Chtimes(cachePath, oldTime, oldTime); err != nil {
+		t.Fatalf("failed to age test cache: %s", err)
+	}
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			requestCount++
+			_, _ = w.Write([]byte(
+				`{"tag_name":"v1.3.0","html_url":"https://example.test/v1.3.0"}`,
+			))
+		},
+	))
+	defer server.Close()
+
+	update, err := checkForUpdate(
+		context.Background(),
+		"v1.2.0",
+		cacheDir,
+		server.URL,
+		server.Client(),
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected version check error: %s", err)
+	}
+	if update == nil || update.LatestVersion != "v1.3.0" {
+		t.Fatalf("unexpected refreshed update: %#v", update)
+	}
+	if requestCount != 1 {
+		t.Fatalf("stale cache should be refreshed, got %d requests", requestCount)
+	}
+}
+
+// TestCheckForUpdateReplacesInvalidCache checks that a cache file containing
+// unparseable content is ignored and replaced with a fresh request, rather
+// than surfacing an error.
+func TestCheckForUpdateReplacesInvalidCache(t *testing.T) {
+	cacheDir := t.TempDir()
+	cachePath := filepath.Join(cacheDir, versionCacheFile)
+	if err := os.WriteFile(cachePath, []byte(`not-json`), 0o600); err != nil {
+		t.Fatalf("failed to write invalid test cache: %s", err)
+	}
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			requestCount++
+			_, _ = w.Write([]byte(
+				`{"tag_name":"v1.3.0","html_url":"https://example.test/v1.3.0"}`,
+			))
+		},
+	))
+	defer server.Close()
+
+	update, err := checkForUpdate(
+		context.Background(),
+		"v1.2.0",
+		cacheDir,
+		server.URL,
+		server.Client(),
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected version check error: %s", err)
+	}
+	if update == nil || update.LatestVersion != "v1.3.0" {
+		t.Fatalf("unexpected update after invalid cache: %#v", update)
+	}
+	if requestCount != 1 {
+		t.Fatalf("invalid cache should be replaced, got %d requests", requestCount)
+	}
+}
+
+// TestCheckForUpdateReturnsNilForCurrentVersion checks that no update is
+// reported when the running version matches the latest published release.
+func TestCheckForUpdateReturnsNilForCurrentVersion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(
+				`{"tag_name":"v1.2.0","html_url":"https://example.test/v1.2.0"}`,
+			))
+		},
+	))
+	defer server.Close()
+
+	update, err := checkForUpdate(
+		context.Background(),
+		"v1.2.0",
+		t.TempDir(),
+		server.URL,
+		server.Client(),
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected version check error: %s", err)
+	}
+	if update != nil {
+		t.Fatalf("did not expect an update notice: %#v", update)
+	}
+}
+
+// TestCheckForUpdateReturnsFetchError checks that a network failure while
+// fetching the latest release is surfaced to the caller as an error.
+func TestCheckForUpdateReturnsFetchError(t *testing.T) {
+	expectedErr := errors.New("offline")
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, expectedErr
+		}),
+	}
+
+	_, err := checkForUpdate(
+		context.Background(),
+		"v1.0.0",
+		t.TempDir(),
+		"https://example.test/latest",
+		client,
+		time.Now(),
+	)
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected fetch error, got: %v", err)
+	}
+}
+
+// TestCheckForUpdateSkipsDevelopmentBuild checks that the version check is
+// skipped entirely (no error, no update) when Version is empty, as it is for
+// non-tagged/development builds.
+func TestCheckForUpdateSkipsDevelopmentBuild(t *testing.T) {
+	originalVersion := Version
+	Version = ""
+	t.Cleanup(func() {
+		Version = originalVersion
+	})
+
+	update, err := CheckForUpdate(t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected development build error: %s", err)
+	}
+	if update != nil {
+		t.Fatalf("development build should not return an update: %#v", update)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/internal/version/check_test.go
+++ b/internal/version/check_test.go
@@ -318,7 +318,7 @@ func TestCheckForUpdateSkipsDevelopmentBuild(t *testing.T) {
 		Version = originalVersion
 	})
 
-	update, err := CheckForUpdate(t.TempDir())
+	update, err := CheckForUpdate(t.TempDir(), http.DefaultClient)
 	if err != nil {
 		t.Fatalf("unexpected development build error: %s", err)
 	}


### PR DESCRIPTION
1. Added a cached, once-per-24h check that warns users when a newer cardano-up release is available.
2. `internal/version/check.go` (new) — Added `CheckForUpdate` where it fetches the latest GitHub release, cached for 24h in `latest_version.json` under the OS cache dir, and returns an `Update` only when the release is newer than the running version.
3. `internal/version/check.go` — Added `checkForUpdate` where it holds the core logic (context, cache dir, release URL, HTTP client, clock all passed in) so it's testable without real network/time.
4. `internal/version/check.go` — Added `loadCachedRelease` in which it reads the cache file and returns nil if it's missing, stale (>24h), or fails validation (corrupt JSON or an unparseable `tag_name`)
5. `internal/version/check.go` —  Added `fetchLatestRelease` where it calls the GitHub releases API with the `application/vnd.github+json` accept header and API version header.
6. `internal/version/check.go` — Added `saveCachedRelease` and writes the release to a temp file and renames it into place (atomic on the same filesystem), so a process that exits mid-write can't leave a truncated cache file; failures here are best-effort and don't block the update notice.
8. `cmd/cardano-up/main.go` — The version check now runs in a goroutine started from the root command's `PersistentPreRun`, concurrently with the invoked command itself, so a slow/unreachable endpoint doesn't delay the start of command execution. `main(`) waits for that goroutine after `Execute()` returns (bounded by versionCheckTimeout) so the cache write and notice reliably complete for commands that return normally — this doesn't cover the handful of pre-existing subcommands that call os.Exit directly on failure instead of returning an error, which is a separate, larger refactor outside this change's scope.
9. `cmd/cardano-up/main.go` — Added `checkForNewVersion` in which it resolves the cache dir, calls `CheckForUpdate`, and logs a `slog.Warn` with current/latest version and release URL; errors are only logged at debug level.
10. `cmd/cardano-up/main.go` —  Added `shouldCheckForNewVersion` where it skips the check for `context env`, `version`, help, any completion subcommand, and cobra's hidden `__complete`/`__completeNoDesc` commands (invoked by shells on every TAB keypress during interactive completion)."
11. `internal/version/check_test.go` (new) — Added unit tests for fetch+cache, stale-cache refresh, invalid-cache replacement, malformed cached tag, malformed fetched tag (and that it's never cached), no-update-when-current, fetch-error propagation, and dev-build skip.
12. `cmd/cardano-up/main_test.go` (new) — Added a test for `shouldCheckForNewVersion` across the real cobra command tree, including the hidden shell-completion-request command.

Closes #338 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a once-per-24h version check that runs alongside command execution and warns on stderr after completion if a newer `cardano-up` release is available. It never delays command start, uses a cached 1.5s‑bounded GitHub query, and can be disabled with `NO_UPDATE_CHECK`. Closes #338.

- **New Features**
  - Checks GitHub’s latest release with a 24h cache (`latest_version.json` in the OS cache dir) and a 1.5s timeout; atomic cache writes; uses `github.com/hashicorp/go-version` for semver.
  - Runs from the root command’s PersistentPreRun in a goroutine; main waits up to 2s; warning (current/latest and release URL) goes to stderr; errors are debug-only; skips `context env`, `version`, `help`, any `completion`, and hidden `__complete`/`__completeNoDesc`.

- **Refactors**
  - Inject `*http.Client` into `checkForNewVersion` and `version.CheckForUpdate` so tests can pass a custom client; tests verify env opt‑out makes no network calls and validate the skip list on the real cobra tree.
  - Remove orphaned temp file if the cache file rename fails during atomic write; reuse the parsed tag version from cache/API helpers instead of re-parsing.

<sup>Written for commit 763231353f0d38b4ba854711b286f1571ab6f5d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up/pull/572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic checks for newer releases during command execution.
  * Displays a warning when an update is available, including a link to the release.
  * Uses cached results for 24 hours to minimize network requests.
  * Skips checks for development builds and commands where updates are not relevant.

* **Bug Fixes**
  * Handles unavailable or invalid cached update data by refreshing it automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->