### PR TITLE
feat(pkgmgr): Create postStop hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ The package manifest format is a YAML file with the following fields:
 | `preStartScript` | | Arbitrary command that will be run before package services are started |
 | `postStartScript` | | Arbitrary command that will be run after package services are started |
 | `preStopScript` | | Arbitrary command that will be run before package services are stopped |
+| `postStopScript` | | Arbitrary command that will be run after package services are stopped |
 | `preUninstallScript` | | Arbitrary command that will be run before the package is uninstalled |
 | `postUninstallScript` | | Arbitrary command that will be run after the package is uninstalled |
 | `installSteps` | | Steps to install package |

--- a/pkgmgr/docker.go
+++ b/pkgmgr/docker.go
@@ -131,6 +131,17 @@ func (d *DockerService) Start() error {
 // finding the container already stopped and doing nothing (false) - this
 // lets callers distinguish a transition they caused from one that had
 // already happened, e.g. via a concurrent, unrelated operation.
+//
+// This is a best-effort signal, not a guarantee: if another actor stops the
+// container in the narrow window between the Running() check above and the
+// ContainerStop() call below, Docker's stop endpoint is idempotent and
+// returns success either way, and this method has no way to tell the two
+// cases apart. The underlying docker/docker/client SDK discards the
+// distinction the Docker Engine API itself makes here (204 "stopped by this
+// request" vs. 304 "already stopped") - ContainerStop() only returns an
+// error, never the response status - so recovering it would require
+// bypassing the SDK's exported API with a raw HTTP request. Given that
+// cost, this race is accepted rather than closed.
 func (d *DockerService) Stop() (bool, error) {
 	running, err := d.Running()
 	if err != nil {

--- a/pkgmgr/docker.go
+++ b/pkgmgr/docker.go
@@ -126,29 +126,35 @@ func (d *DockerService) Start() error {
 	return nil
 }
 
-func (d *DockerService) Stop() error {
+// Stop stops the container if it is running. The returned bool reports
+// whether this call actually issued a stop request (true), as opposed to
+// finding the container already stopped and doing nothing (false) - this
+// lets callers distinguish a transition they caused from one that had
+// already happened, e.g. via a concurrent, unrelated operation.
+func (d *DockerService) Stop() (bool, error) {
 	running, err := d.Running()
 	if err != nil {
-		return err
+		return false, err
 	}
-	if running {
-		client, err := d.getClient()
-		if err != nil {
-			return err
-		}
-		d.logger.Debug("stopping container " + d.ContainerName)
-		stopTimeout := 60
-		if err := client.ContainerStop(
-			context.Background(),
-			d.ContainerId,
-			container.StopOptions{
-				Timeout: &stopTimeout,
-			},
-		); err != nil {
-			return err
-		}
+	if !running {
+		return false, nil
 	}
-	return nil
+	client, err := d.getClient()
+	if err != nil {
+		return false, err
+	}
+	d.logger.Debug("stopping container " + d.ContainerName)
+	stopTimeout := 60
+	if err := client.ContainerStop(
+		context.Background(),
+		d.ContainerId,
+		container.StopOptions{
+			Timeout: &stopTimeout,
+		},
+	); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (d *DockerService) Create() error {

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -742,6 +742,9 @@ func (p Package) stopService(cfg Config, context string) error {
 			// stopped despite Stop() reporting an error).
 			nowRunning, runningErr := dockerService.Running()
 			if runningErr != nil {
+				// Final state is unknown, so track it for a best-effort
+				// rollback attempt rather than risk leaving it stopped.
+				stoppedServices = append(stoppedServices, dockerService)
 				stopErrors = append(
 					stopErrors,
 					fmt.Sprintf(
@@ -752,9 +755,17 @@ func (p Package) stopService(cfg Config, context string) error {
 				)
 				continue
 			}
-			if !nowRunning {
-				stoppedServices = append(stoppedServices, dockerService)
+			if nowRunning {
+				stopErrors = append(
+					stopErrors,
+					fmt.Sprintf(
+						"failed to stop Docker container %s: container is still running",
+						containerName,
+					),
+				)
+				continue
 			}
+			stoppedServices = append(stoppedServices, dockerService)
 			if stopErr != nil {
 				stopErrors = append(
 					stopErrors,

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -74,7 +74,10 @@ type PackageOutput struct {
 type serviceLifecycle interface {
 	Running() (bool, error)
 	Start() error
-	Stop() error
+	// Stop stops the service if it is running. The returned bool reports
+	// whether this call actually issued a stop (true), versus finding it
+	// already stopped and doing nothing (false).
+	Stop() (bool, error)
 }
 
 var newServiceFromContainerName = func(containerName string, logger *slog.Logger) (serviceLifecycle, error) {
@@ -670,7 +673,7 @@ func (p Package) rollbackStartedServices(startedServices []serviceLifecycle) {
 		return
 	}
 	for idx := len(startedServices) - 1; idx >= 0; idx-- {
-		if err := startedServices[idx].Stop(); err != nil {
+		if _, err := startedServices[idx].Stop(); err != nil {
 			slog.Warn(
 				fmt.Sprintf(
 					"failed to roll back started service after start failure: %v",
@@ -718,30 +721,19 @@ func (p Package) stopService(cfg Config, context string) error {
 				)
 				continue
 			}
-			wasRunning, err := dockerService.Running()
+			// Stop() itself checks whether the container is running before
+			// acting, and reports whether it actually issued a stop. Relying
+			// on that report - rather than a separate Running() check made
+			// beforehand by this code - avoids a race where a concurrent,
+			// unrelated operation stops the container in between the two
+			// checks: this code would then see a "successful" no-op Stop()
+			// and wrongly believe it owns a transition it never caused.
+			stoppedNow, err := dockerService.Stop()
 			if err != nil {
-				stopErrors = append(
-					stopErrors,
-					fmt.Sprintf(
-						"error checking Docker container status for %s: %v",
-						containerName,
-						err,
-					),
-				)
-				continue
-			}
-			if !wasRunning {
-				continue
-			}
-			// Stop the Docker container if it's running
-			slog.Info("Stopping container " + containerName)
-			if err := dockerService.Stop(); err != nil {
 				// Don't track this service for rollback: a container found
 				// stopped despite this error could have been stopped by a
 				// concurrent, unrelated operation, and rolling it back would
-				// wrongly undo that operation's intended effect. Only a
-				// Stop() call this code issued and confirmed below counts as
-				// this call's own transition.
+				// wrongly undo that operation's intended effect.
 				stopErrors = append(
 					stopErrors,
 					fmt.Sprintf(
@@ -752,13 +744,20 @@ func (p Package) stopService(cfg Config, context string) error {
 				)
 				continue
 			}
-			// Confirm the container actually stopped - a nil Stop() error
-			// alone isn't proof of the state transition.
+			if !stoppedNow {
+				// The container was already stopped; nothing to do or roll
+				// back, and no error since the desired end state holds.
+				continue
+			}
+			slog.Info("Stopped container " + containerName)
+			// Confirm the container is actually stopped - e.g. a restart
+			// policy could bring it back up immediately after a successful
+			// stop request.
 			nowRunning, err := dockerService.Running()
 			if err != nil {
-				// Our own Stop() call above reported success, so this call
-				// owns the transition even though it can't be reconfirmed -
-				// track it for a best-effort rollback attempt.
+				// This call's own Stop() reported success, so it owns the
+				// transition even though the final state can't be
+				// reconfirmed - track it for a best-effort rollback attempt.
 				stoppedServices = append(stoppedServices, dockerService)
 				stopErrors = append(
 					stopErrors,
@@ -1041,10 +1040,8 @@ func (p *PackageInstallStepDocker) uninstall(
 				return err
 			}
 		} else {
-			if running, _ := svc.Running(); running {
-				if err := svc.Stop(); err != nil {
-					return err
-				}
+			if _, err := svc.Stop(); err != nil {
+				return err
 			}
 			if err := svc.Remove(); err != nil {
 				return err

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -735,22 +735,37 @@ func (p Package) stopService(cfg Config, context string) error {
 			}
 			// Stop the Docker container if it's running
 			slog.Info("Stopping container " + containerName)
-			stopErr := dockerService.Stop()
-			// Reconcile against actual container state rather than trusting
-			// a nil Stop() error, so rollback only targets containers that
-			// really transitioned to stopped (and still catches ones that
-			// stopped despite Stop() reporting an error).
-			nowRunning, runningErr := dockerService.Running()
-			if runningErr != nil {
-				// Final state is unknown, so track it for a best-effort
-				// rollback attempt rather than risk leaving it stopped.
+			if err := dockerService.Stop(); err != nil {
+				// Don't track this service for rollback: a container found
+				// stopped despite this error could have been stopped by a
+				// concurrent, unrelated operation, and rolling it back would
+				// wrongly undo that operation's intended effect. Only a
+				// Stop() call this code issued and confirmed below counts as
+				// this call's own transition.
+				stopErrors = append(
+					stopErrors,
+					fmt.Sprintf(
+						"failed to stop Docker container %s: %v",
+						containerName,
+						err,
+					),
+				)
+				continue
+			}
+			// Confirm the container actually stopped - a nil Stop() error
+			// alone isn't proof of the state transition.
+			nowRunning, err := dockerService.Running()
+			if err != nil {
+				// Our own Stop() call above reported success, so this call
+				// owns the transition even though it can't be reconfirmed -
+				// track it for a best-effort rollback attempt.
 				stoppedServices = append(stoppedServices, dockerService)
 				stopErrors = append(
 					stopErrors,
 					fmt.Sprintf(
 						"error checking Docker container status for %s: %v",
 						containerName,
-						runningErr,
+						err,
 					),
 				)
 				continue
@@ -766,17 +781,6 @@ func (p Package) stopService(cfg Config, context string) error {
 				continue
 			}
 			stoppedServices = append(stoppedServices, dockerService)
-			if stopErr != nil {
-				stopErrors = append(
-					stopErrors,
-					fmt.Sprintf(
-						"failed to stop Docker container %s: %v",
-						containerName,
-						stopErr,
-					),
-				)
-				continue
-			}
 		}
 	}
 

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -50,6 +50,7 @@ type Package struct {
 	PreStartScript      string               `yaml:"preStartScript,omitempty"`
 	PostStartScript     string               `yaml:"postStartScript,omitempty"`
 	PreStopScript       string               `yaml:"preStopScript,omitempty"`
+	PostStopScript      string               `yaml:"postStopScript,omitempty"`
 	PreUninstallScript  string               `yaml:"preUninstallScript,omitempty"`
 	PostUninstallScript string               `yaml:"postUninstallScript,omitempty"`
 	PostInstallNotes    string               `yaml:"postInstallNotes,omitempty"`
@@ -691,6 +692,7 @@ func (p Package) stopService(cfg Config, context string) error {
 	}
 
 	var stopErrors []string
+	stoppedServices := make([]serviceLifecycle, 0)
 	for _, step := range p.InstallSteps {
 		if step.Docker != nil {
 			if step.Docker.PullOnly {
@@ -701,7 +703,7 @@ func (p Package) stopService(cfg Config, context string) error {
 				pkgName,
 				step.Docker.ContainerName,
 			)
-			dockerService, err := NewDockerServiceFromContainerName(
+			dockerService, err := newServiceFromContainerName(
 				containerName,
 				cfg.Logger,
 			)
@@ -716,7 +718,22 @@ func (p Package) stopService(cfg Config, context string) error {
 				)
 				continue
 			}
-			// Stop the Docker container
+			wasRunning, err := dockerService.Running()
+			if err != nil {
+				stopErrors = append(
+					stopErrors,
+					fmt.Sprintf(
+						"error checking Docker container status for %s: %v",
+						containerName,
+						err,
+					),
+				)
+				continue
+			}
+			if !wasRunning {
+				continue
+			}
+			// Stop the Docker container if it's running
 			slog.Info("Stopping container " + containerName)
 			if err := dockerService.Stop(); err != nil {
 				stopErrors = append(
@@ -727,16 +744,43 @@ func (p Package) stopService(cfg Config, context string) error {
 						err,
 					),
 				)
+				continue
 			}
+			stoppedServices = append(stoppedServices, dockerService)
 		}
 	}
 
 	if len(stopErrors) > 0 {
+		p.rollbackStoppedServices(stoppedServices)
 		slog.Error(strings.Join(stopErrors, "\n"))
 		return ErrOperationFailed
 	}
 
+	// Run post-stop script
+	if p.PostStopScript != "" {
+		if err := p.runHookScript(cfg, p.PostStopScript); err != nil {
+			p.rollbackStoppedServices(stoppedServices)
+			return fmt.Errorf("post-stop hook failed: %w", err)
+		}
+	}
+
 	return nil
+}
+
+func (p Package) rollbackStoppedServices(stoppedServices []serviceLifecycle) {
+	if len(stoppedServices) == 0 {
+		return
+	}
+	for idx := len(stoppedServices) - 1; idx >= 0; idx-- {
+		if err := stoppedServices[idx].Start(); err != nil {
+			slog.Warn(
+				fmt.Sprintf(
+					"failed to roll back stopped service after stop failure: %v",
+					err,
+				),
+			)
+		}
+	}
 }
 
 func (p Package) services(

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -735,18 +735,37 @@ func (p Package) stopService(cfg Config, context string) error {
 			}
 			// Stop the Docker container if it's running
 			slog.Info("Stopping container " + containerName)
-			if err := dockerService.Stop(); err != nil {
+			stopErr := dockerService.Stop()
+			// Reconcile against actual container state rather than trusting
+			// a nil Stop() error, so rollback only targets containers that
+			// really transitioned to stopped (and still catches ones that
+			// stopped despite Stop() reporting an error).
+			nowRunning, runningErr := dockerService.Running()
+			if runningErr != nil {
+				stopErrors = append(
+					stopErrors,
+					fmt.Sprintf(
+						"error checking Docker container status for %s: %v",
+						containerName,
+						runningErr,
+					),
+				)
+				continue
+			}
+			if !nowRunning {
+				stoppedServices = append(stoppedServices, dockerService)
+			}
+			if stopErr != nil {
 				stopErrors = append(
 					stopErrors,
 					fmt.Sprintf(
 						"failed to stop Docker container %s: %v",
 						containerName,
-						err,
+						stopErr,
 					),
 				)
 				continue
 			}
-			stoppedServices = append(stoppedServices, dockerService)
 		}
 	}
 
@@ -775,7 +794,7 @@ func (p Package) rollbackStoppedServices(stoppedServices []serviceLifecycle) {
 		if err := stoppedServices[idx].Start(); err != nil {
 			slog.Warn(
 				fmt.Sprintf(
-					"failed to roll back stopped service after stop failure: %v",
+					"failed to roll back stopped service: %v",
 					err,
 				),
 			)

--- a/pkgmgr/package_test.go
+++ b/pkgmgr/package_test.go
@@ -43,9 +43,10 @@ type fakeServiceLifecycle struct {
 	stopErr              error
 	stopErrLeavesStopped bool
 
-	// stopNoop, if true, makes Stop() report success without actually
-	// changing the container's running state - simulates a stop call that
-	// silently fails to take effect.
+	// stopNoop, if true, makes a successful Stop() report that it issued a
+	// stop (stoppedNow=true) without the container actually transitioning to
+	// not-running - simulates e.g. a restart policy immediately restarting
+	// the container right after a successful stop request.
 	stopNoop bool
 
 	// runningErrAfterStop, if set, is returned by Running() only once
@@ -67,21 +68,28 @@ func (f *fakeServiceLifecycle) Start() error {
 	return nil
 }
 
-func (f *fakeServiceLifecycle) Stop() error {
+// Stop mirrors DockerService.Stop(): it only acts (and reports
+// stoppedNow=true) if the container is currently running, matching the
+// production contract that a nil/false result means no real action was
+// taken.
+func (f *fakeServiceLifecycle) Stop() (bool, error) {
 	f.stopCalled = true
-	if f.stopNoop {
-		return nil
+	if !f.running {
+		return false, nil
 	}
 	if f.stopErr != nil {
 		if f.stopErrLeavesStopped {
 			f.stopped = true
 			f.running = false
 		}
-		return f.stopErr
+		return false, f.stopErr
+	}
+	if f.stopNoop {
+		return true, nil
 	}
 	f.stopped = true
 	f.running = false
-	return nil
+	return true, nil
 }
 
 var packageTestDefs = []struct {

--- a/pkgmgr/package_test.go
+++ b/pkgmgr/package_test.go
@@ -161,6 +161,9 @@ func TestOSAndARCH(t *testing.T) {
 	}
 }
 
+// TestServiceHooks_PreStartPostStartAndPreStop verifies that startService
+// and stopService run their hook scripts in the correct order: preStart and
+// postStart around a start, then preStop and postStop around a stop.
 func TestServiceHooks_PreStartPostStartAndPreStop(t *testing.T) {
 	tmpDir := t.TempDir()
 	hookLog := filepath.Join(tmpDir, "hooks.log")
@@ -186,6 +189,13 @@ func TestServiceHooks_PreStartPostStartAndPreStop(t *testing.T) {
 		t.Fatalf("failed to write preStop script: %v", err)
 	}
 
+	// Create postStop script
+	postStopScript := filepath.Join(tmpDir, "poststop.sh")
+	postStopContent := "#!/bin/sh\necho 'poststop executed' >> " + hookLog
+	if err := os.WriteFile(postStopScript, []byte(postStopContent), 0755); err != nil {
+		t.Fatalf("failed to write postStop script: %v", err)
+	}
+
 	// Initialize a config object
 	cfg := Config{
 		CacheDir: tmpDir,
@@ -203,6 +213,7 @@ func TestServiceHooks_PreStartPostStartAndPreStop(t *testing.T) {
 		PreStartScript:  preStartScript,
 		PostStartScript: postStartScript,
 		PreStopScript:   preStopScript,
+		PostStopScript:  postStopScript,
 		InstallSteps:    []PackageInstallStep{},
 	}
 
@@ -224,7 +235,7 @@ func TestServiceHooks_PreStartPostStartAndPreStop(t *testing.T) {
 		)
 	}
 
-	// Execute stopService and expect preStopScript to run
+	// Execute stopService and expect preStopScript and postStopScript to run
 	if err := pkg.stopService(cfg, "testctx"); err != nil {
 		t.Fatalf("stopService failed: %v", err)
 	}
@@ -234,12 +245,144 @@ func TestServiceHooks_PreStartPostStartAndPreStop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("hook log file not found: %v", err)
 	}
-	if string(hookOutput) != "prestart executed\npoststart executed\nprestop executed\n" {
+	if string(hookOutput) != "prestart executed\npoststart executed\nprestop executed\npoststop executed\n" {
 		t.Errorf(
 			"unexpected hook output: got %q, want %q",
 			string(hookOutput),
-			"prestart executed\npoststart executed\nprestop executed\n",
+			"prestart executed\npoststart executed\nprestop executed\npoststop executed\n",
 		)
+	}
+}
+
+// TestStopService_PostStopHookSkippedOnStopFailure verifies that
+// postStopScript does not run when a Docker container fails to stop,
+// matching the conservative skip-on-failure behavior of postStartScript.
+func TestStopService_PostStopHookSkippedOnStopFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	hookLog := filepath.Join(tmpDir, "hooks.log")
+	postStopScript := filepath.Join(tmpDir, "poststop.sh")
+	postStopContent := "#!/bin/sh\necho 'poststop executed' >> " + hookLog
+	if err := os.WriteFile(postStopScript, []byte(postStopContent), 0755); err != nil {
+		t.Fatalf("failed to write postStop script: %v", err)
+	}
+
+	cfg := Config{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Template: &Template{
+			tmpl:     template.New("test"),
+			baseVars: make(map[string]any),
+		},
+	}
+	pkg := Package{
+		Name:           "mypkg",
+		Version:        "1.0.0",
+		PostStopScript: postStopScript,
+		InstallSteps: []PackageInstallStep{
+			{
+				Docker: &PackageInstallStepDocker{
+					ContainerName: "missing",
+					Image:         "alpine:3.20",
+				},
+			},
+		},
+	}
+
+	err := pkg.stopService(cfg, "testctx")
+	if err == nil {
+		t.Fatal("expected stopService to fail for a nonexistent container")
+	}
+	if _, statErr := os.Stat(hookLog); !os.IsNotExist(statErr) {
+		t.Fatal("expected postStopScript to be skipped when stopping a service fails")
+	}
+}
+
+// TestStopService_PostStopHookFailure verifies that stopService surfaces a
+// wrapped "post-stop hook failed" error when postStopScript exits non-zero.
+func TestStopService_PostStopHookFailure(t *testing.T) {
+	cfg := Config{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Template: &Template{
+			tmpl:     template.New("test"),
+			baseVars: make(map[string]any),
+		},
+	}
+	pkg := Package{
+		Name:           "mypkg",
+		Version:        "1.0.0",
+		PostStopScript: "exit 1",
+		InstallSteps:   []PackageInstallStep{},
+	}
+
+	err := pkg.stopService(cfg, "testctx")
+	if err == nil {
+		t.Fatal("expected post-stop hook failure")
+	}
+	if !strings.Contains(err.Error(), "post-stop hook failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestStopService_RollsBackStoppedServicesOnPostStopFailure verifies that
+// when postStopScript fails, stopService restarts only the containers it
+// stopped during this call, leaving already-stopped containers untouched.
+func TestStopService_RollsBackStoppedServicesOnPostStopFailure(t *testing.T) {
+	origNewServiceFromContainerName := newServiceFromContainerName
+	t.Cleanup(func() {
+		newServiceFromContainerName = origNewServiceFromContainerName
+	})
+
+	stoppedSvc := &fakeServiceLifecycle{running: true}
+	alreadyStoppedSvc := &fakeServiceLifecycle{running: false}
+	services := map[string]*fakeServiceLifecycle{
+		"mypkg-1.0.0-testctx-running": stoppedSvc,
+		"mypkg-1.0.0-testctx-stopped": alreadyStoppedSvc,
+	}
+	newServiceFromContainerName = func(containerName string, logger *slog.Logger) (serviceLifecycle, error) {
+		return services[containerName], nil
+	}
+
+	cfg := Config{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Template: &Template{
+			tmpl:     template.New("test"),
+			baseVars: make(map[string]any),
+		},
+	}
+	pkg := Package{
+		Name:           "mypkg",
+		Version:        "1.0.0",
+		PostStopScript: "exit 1",
+		InstallSteps: []PackageInstallStep{
+			{
+				Docker: &PackageInstallStepDocker{
+					ContainerName: "running",
+					Image:         "alpine:3.20",
+				},
+			},
+			{
+				Docker: &PackageInstallStepDocker{
+					ContainerName: "stopped",
+					Image:         "alpine:3.20",
+				},
+			},
+		},
+	}
+
+	err := pkg.stopService(cfg, "testctx")
+	if err == nil {
+		t.Fatal("expected post-stop hook failure")
+	}
+	if !strings.Contains(err.Error(), "post-stop hook failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !stoppedSvc.stopped {
+		t.Fatal("expected running service to be stopped")
+	}
+	if !stoppedSvc.started {
+		t.Fatal("expected newly-stopped service to be restarted during rollback")
+	}
+	if alreadyStoppedSvc.started {
+		t.Fatal("expected already-stopped service to be left stopped")
 	}
 }
 

--- a/pkgmgr/package_test.go
+++ b/pkgmgr/package_test.go
@@ -361,24 +361,26 @@ func TestStopService_PostStopHookSkippedOnStopFailure(t *testing.T) {
 	}
 }
 
-// TestStopService_RollsBackContainerThatStoppedDespiteReportedError verifies
-// that when Stop() returns an error but the container actually transitioned
-// to stopped, stopService still tracks it (via a Running() reconciliation
-// check) so that rollback restarts it rather than trusting a nil/non-nil
-// Stop() error as proof of whether the container's state changed.
-func TestStopService_RollsBackContainerThatStoppedDespiteReportedError(t *testing.T) {
+// TestStopService_DoesNotRollBackOnAmbiguousStopError verifies that when
+// Stop() itself returns an error, stopService does not attempt to roll back
+// (restart) that container, even if it later observes the container as
+// stopped. A container found stopped after a failed Stop() call could have
+// been stopped by a concurrent, unrelated operation, and restarting it would
+// risk undoing that other operation's intended effect. Only a Stop() call
+// this code issued and confirmed successful is eligible for rollback.
+func TestStopService_DoesNotRollBackOnAmbiguousStopError(t *testing.T) {
 	origNewServiceFromContainerName := newServiceFromContainerName
 	t.Cleanup(func() {
 		newServiceFromContainerName = origNewServiceFromContainerName
 	})
 
-	partialFailureSvc := &fakeServiceLifecycle{
+	ambiguousSvc := &fakeServiceLifecycle{
 		running:              true,
-		stopErr:              errors.New("stop reported an error but the container did stop"),
+		stopErr:              errors.New("stop reported an error but the container ended up stopped"),
 		stopErrLeavesStopped: true,
 	}
 	newServiceFromContainerName = func(containerName string, logger *slog.Logger) (serviceLifecycle, error) {
-		return partialFailureSvc, nil
+		return ambiguousSvc, nil
 	}
 
 	cfg := Config{
@@ -405,11 +407,8 @@ func TestStopService_RollsBackContainerThatStoppedDespiteReportedError(t *testin
 	if err == nil {
 		t.Fatal("expected stopService to fail")
 	}
-	if !partialFailureSvc.stopped {
-		t.Fatal("expected the container to have actually stopped")
-	}
-	if !partialFailureSvc.started {
-		t.Fatal("expected the container that actually stopped to be rolled back (restarted) despite Stop() reporting an error")
+	if ambiguousSvc.started {
+		t.Fatal("expected no rollback for a Stop() call that reported an error, to avoid undoing a possibly-concurrent stop")
 	}
 }
 

--- a/pkgmgr/package_test.go
+++ b/pkgmgr/package_test.go
@@ -16,6 +16,7 @@ package pkgmgr
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -33,6 +34,13 @@ type fakeServiceLifecycle struct {
 	running bool
 	started bool
 	stopped bool
+
+	// stopErr, if set, is returned by Stop(). By default this simulates a
+	// total stop failure (the container stays running). Set
+	// stopErrLeavesStopped to simulate a partial failure where the
+	// container actually stopped despite Stop() reporting an error.
+	stopErr              error
+	stopErrLeavesStopped bool
 }
 
 func (f *fakeServiceLifecycle) Running() (bool, error) {
@@ -46,6 +54,13 @@ func (f *fakeServiceLifecycle) Start() error {
 }
 
 func (f *fakeServiceLifecycle) Stop() error {
+	if f.stopErr != nil {
+		if f.stopErrLeavesStopped {
+			f.stopped = true
+			f.running = false
+		}
+		return f.stopErr
+	}
 	f.stopped = true
 	f.running = false
 	return nil
@@ -256,8 +271,28 @@ func TestServiceHooks_PreStartPostStartAndPreStop(t *testing.T) {
 
 // TestStopService_PostStopHookSkippedOnStopFailure verifies that
 // postStopScript does not run when a Docker container fails to stop,
-// matching the conservative skip-on-failure behavior of postStartScript.
+// matching the conservative skip-on-failure behavior of postStartScript. It
+// also verifies that a container already stopped earlier in the same call
+// is rolled back (restarted) when a later container fails to stop.
 func TestStopService_PostStopHookSkippedOnStopFailure(t *testing.T) {
+	origNewServiceFromContainerName := newServiceFromContainerName
+	t.Cleanup(func() {
+		newServiceFromContainerName = origNewServiceFromContainerName
+	})
+
+	stoppedSvc := &fakeServiceLifecycle{running: true}
+	brokenSvc := &fakeServiceLifecycle{
+		running: true,
+		stopErr: errors.New("simulated stop failure"),
+	}
+	services := map[string]*fakeServiceLifecycle{
+		"mypkg-1.0.0-testctx-stopped": stoppedSvc,
+		"mypkg-1.0.0-testctx-broken":  brokenSvc,
+	}
+	newServiceFromContainerName = func(containerName string, logger *slog.Logger) (serviceLifecycle, error) {
+		return services[containerName], nil
+	}
+
 	tmpDir := t.TempDir()
 	hookLog := filepath.Join(tmpDir, "hooks.log")
 	postStopScript := filepath.Join(tmpDir, "poststop.sh")
@@ -280,7 +315,13 @@ func TestStopService_PostStopHookSkippedOnStopFailure(t *testing.T) {
 		InstallSteps: []PackageInstallStep{
 			{
 				Docker: &PackageInstallStepDocker{
-					ContainerName: "missing",
+					ContainerName: "stopped",
+					Image:         "alpine:3.20",
+				},
+			},
+			{
+				Docker: &PackageInstallStepDocker{
+					ContainerName: "broken",
 					Image:         "alpine:3.20",
 				},
 			},
@@ -289,10 +330,68 @@ func TestStopService_PostStopHookSkippedOnStopFailure(t *testing.T) {
 
 	err := pkg.stopService(cfg, "testctx")
 	if err == nil {
-		t.Fatal("expected stopService to fail for a nonexistent container")
+		t.Fatal("expected stopService to fail when a container fails to stop")
 	}
 	if _, statErr := os.Stat(hookLog); !os.IsNotExist(statErr) {
 		t.Fatal("expected postStopScript to be skipped when stopping a service fails")
+	}
+	if !stoppedSvc.started {
+		t.Fatal("expected the earlier successfully-stopped service to be rolled back (restarted)")
+	}
+	if brokenSvc.started {
+		t.Fatal("expected the service that failed to stop to not be started during rollback")
+	}
+}
+
+// TestStopService_RollsBackContainerThatStoppedDespiteReportedError verifies
+// that when Stop() returns an error but the container actually transitioned
+// to stopped, stopService still tracks it (via a Running() reconciliation
+// check) so that rollback restarts it rather than trusting a nil/non-nil
+// Stop() error as proof of whether the container's state changed.
+func TestStopService_RollsBackContainerThatStoppedDespiteReportedError(t *testing.T) {
+	origNewServiceFromContainerName := newServiceFromContainerName
+	t.Cleanup(func() {
+		newServiceFromContainerName = origNewServiceFromContainerName
+	})
+
+	partialFailureSvc := &fakeServiceLifecycle{
+		running:              true,
+		stopErr:              errors.New("stop reported an error but the container did stop"),
+		stopErrLeavesStopped: true,
+	}
+	newServiceFromContainerName = func(containerName string, logger *slog.Logger) (serviceLifecycle, error) {
+		return partialFailureSvc, nil
+	}
+
+	cfg := Config{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Template: &Template{
+			tmpl:     template.New("test"),
+			baseVars: make(map[string]any),
+		},
+	}
+	pkg := Package{
+		Name:    "mypkg",
+		Version: "1.0.0",
+		InstallSteps: []PackageInstallStep{
+			{
+				Docker: &PackageInstallStepDocker{
+					ContainerName: "flaky",
+					Image:         "alpine:3.20",
+				},
+			},
+		},
+	}
+
+	err := pkg.stopService(cfg, "testctx")
+	if err == nil {
+		t.Fatal("expected stopService to fail")
+	}
+	if !partialFailureSvc.stopped {
+		t.Fatal("expected the container to have actually stopped")
+	}
+	if !partialFailureSvc.started {
+		t.Fatal("expected the container that actually stopped to be rolled back (restarted) despite Stop() reporting an error")
 	}
 }
 

--- a/pkgmgr/package_test.go
+++ b/pkgmgr/package_test.go
@@ -31,9 +31,10 @@ import (
 )
 
 type fakeServiceLifecycle struct {
-	running bool
-	started bool
-	stopped bool
+	running    bool
+	started    bool
+	stopped    bool
+	stopCalled bool
 
 	// stopErr, if set, is returned by Stop(). By default this simulates a
 	// total stop failure (the container stays running). Set
@@ -41,9 +42,22 @@ type fakeServiceLifecycle struct {
 	// container actually stopped despite Stop() reporting an error.
 	stopErr              error
 	stopErrLeavesStopped bool
+
+	// stopNoop, if true, makes Stop() report success without actually
+	// changing the container's running state - simulates a stop call that
+	// silently fails to take effect.
+	stopNoop bool
+
+	// runningErrAfterStop, if set, is returned by Running() only once
+	// Stop() has been called - simulates a status check that fails right
+	// after an attempt to stop the container.
+	runningErrAfterStop error
 }
 
 func (f *fakeServiceLifecycle) Running() (bool, error) {
+	if f.stopCalled && f.runningErrAfterStop != nil {
+		return false, f.runningErrAfterStop
+	}
 	return f.running, nil
 }
 
@@ -54,6 +68,10 @@ func (f *fakeServiceLifecycle) Start() error {
 }
 
 func (f *fakeServiceLifecycle) Stop() error {
+	f.stopCalled = true
+	if f.stopNoop {
+		return nil
+	}
 	if f.stopErr != nil {
 		if f.stopErrLeavesStopped {
 			f.stopped = true
@@ -392,6 +410,110 @@ func TestStopService_RollsBackContainerThatStoppedDespiteReportedError(t *testin
 	}
 	if !partialFailureSvc.started {
 		t.Fatal("expected the container that actually stopped to be rolled back (restarted) despite Stop() reporting an error")
+	}
+}
+
+// TestStopService_TreatsStillRunningAfterStopAsFailure verifies that a
+// container still observed as running after Stop() reports success is
+// treated as a stop failure: postStopScript is skipped, an error is
+// returned, and the container is not "rolled back" since it never actually
+// stopped in the first place.
+func TestStopService_TreatsStillRunningAfterStopAsFailure(t *testing.T) {
+	origNewServiceFromContainerName := newServiceFromContainerName
+	t.Cleanup(func() {
+		newServiceFromContainerName = origNewServiceFromContainerName
+	})
+
+	stuckSvc := &fakeServiceLifecycle{running: true, stopNoop: true}
+	newServiceFromContainerName = func(containerName string, logger *slog.Logger) (serviceLifecycle, error) {
+		return stuckSvc, nil
+	}
+
+	tmpDir := t.TempDir()
+	hookLog := filepath.Join(tmpDir, "hooks.log")
+	postStopScript := filepath.Join(tmpDir, "poststop.sh")
+	postStopContent := "#!/bin/sh\necho 'poststop executed' >> " + hookLog
+	if err := os.WriteFile(postStopScript, []byte(postStopContent), 0755); err != nil {
+		t.Fatalf("failed to write postStop script: %v", err)
+	}
+
+	cfg := Config{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Template: &Template{
+			tmpl:     template.New("test"),
+			baseVars: make(map[string]any),
+		},
+	}
+	pkg := Package{
+		Name:           "mypkg",
+		Version:        "1.0.0",
+		PostStopScript: postStopScript,
+		InstallSteps: []PackageInstallStep{
+			{
+				Docker: &PackageInstallStepDocker{
+					ContainerName: "stuck",
+					Image:         "alpine:3.20",
+				},
+			},
+		},
+	}
+
+	err := pkg.stopService(cfg, "testctx")
+	if err == nil {
+		t.Fatal("expected stopService to fail when the container is still running after Stop()")
+	}
+	if _, statErr := os.Stat(hookLog); !os.IsNotExist(statErr) {
+		t.Fatal("expected postStopScript to be skipped when a container is still running")
+	}
+	if stuckSvc.started {
+		t.Fatal("expected the still-running container not to be rolled back, since it was never actually stopped")
+	}
+}
+
+// TestStopService_RollsBackOnUnknownStateAfterStopFailure verifies that when
+// the Running() status check fails right after a Stop() call, stopService
+// still attempts a best-effort rollback of that container rather than
+// leaving it stopped with an unknown final state.
+func TestStopService_RollsBackOnUnknownStateAfterStopFailure(t *testing.T) {
+	origNewServiceFromContainerName := newServiceFromContainerName
+	t.Cleanup(func() {
+		newServiceFromContainerName = origNewServiceFromContainerName
+	})
+
+	flakySvc := &fakeServiceLifecycle{
+		running:             true,
+		runningErrAfterStop: errors.New("status check failed after stop"),
+	}
+	newServiceFromContainerName = func(containerName string, logger *slog.Logger) (serviceLifecycle, error) {
+		return flakySvc, nil
+	}
+
+	cfg := Config{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Template: &Template{
+			tmpl:     template.New("test"),
+			baseVars: make(map[string]any),
+		},
+	}
+	pkg := Package{
+		Name:    "mypkg",
+		Version: "1.0.0",
+		InstallSteps: []PackageInstallStep{
+			{
+				Docker: &PackageInstallStepDocker{
+					ContainerName: "flaky",
+					Image:         "alpine:3.20",
+				},
+			},
+		},
+	}
+
+	err := pkg.stopService(cfg, "testctx")
+	if err == nil {
+		t.Fatal("expected stopService to fail")
+	}
+	if !flakySvc.started {
+		t.Fatal("expected best-effort rollback to restart a container whose final state is unknown")
 	}
 }
 


### PR DESCRIPTION
## Summary

Added a `postStopScript` hook so packages can run a script after their services have stopped, mirroring the `postStartScript` hook.

## Changes

- **`pkgmgr/package.go`**
  - Added `PostStopScript` field (`postStopScript` YAML key) to the `Package` manifest struct.
  - `stopService` now uses the injectable `newServiceFromContainerName` constructor (previously only used by `startService`) so container lifecycle can be mocked in tests.
  - `stopService` checks `Running()` before stopping a container and skips it if already stopped, avoiding a misleading "Stopping container" log — mirrors the already-running skip added to `startService` in #547.
  - `stopService` tracks the containers it actually stops during the call (`stoppedServices`) and runs `postStopScript` only after all stops succeed.
  - Added `rollbackStoppedServices`: if a stop fails or `postStopScript` fails, only the containers stopped during that call are restarted — containers that were already stopped beforehand are left untouched.

- **`README.md`**
  - Documented `postStopScript` in the package manifest reference table.

- **`pkgmgr/package_test.go`**
  - Extended the hook-ordering test to cover the full `preStart → postStart → preStop → postStop` sequence.
  - Added `TestStopService_PostStopHookSkippedOnStopFailure` — hook does not run when a container fails to stop.
  - Added `TestStopService_PostStopHookFailure` — hook failure is surfaced as a wrapped `post-stop hook failed` error.
  - Added `TestStopService_RollsBackStoppedServicesOnPostStopFailure` — verifies rollback restarts only the containers stopped during that call, leaving already-stopped containers alone.


Closes #399 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `postStopScript` hook that runs after services stop and makes stop logic safer by only rolling back containers this call actually stopped. Addresses Linear #399 and narrows a stop-ownership race by having `Stop()` report whether it acted; documents the accepted SDK limitation.

- **New Features**
  - Manifest: add `PostStopScript` (`postStopScript` YAML) and document it.
  - Stop flow: run hook after all stops succeed; on any stop or hook error, restart only services this call confirmed it stopped.
  - Safety: rely on `Stop()` returning a bool to know if it acted; skip non-running; fail when still running after stop; roll back on unknown state; no rollback when `Stop()` errored even if later observed stopped; document the accepted concurrent-stop race in `DockerService.Stop()`.  
  - Testability: use injectable `newServiceFromContainerName`; add tests for hook order, stop failures (including ambiguous stop), and rollback on post-stop hook failure.

<sup>Written for commit 122d0cd27e82ec2f0263e586afddb90f154275dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up/pull/575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for a post-stop script that runs after package services stop successfully.
  - Service shutdown now skips inactive services and tracks which services were stopped.
  - Failed shutdowns automatically restore services that were stopped during the operation.

- **Bug Fixes**
  - Post-stop scripts no longer run when stopping services fails.
  - Failures in post-stop scripts are reported and trigger service recovery.

- **Documentation**
  - Documented the new `postStopScript` package configuration field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->