### PR TITLE
fix(pkgmgr): run preStart hook before starting services on install

### DIFF
--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -227,6 +227,15 @@ func (p Package) install(
 			return "", nil, nil, ErrNoInstallMethods
 		}
 	}
+	// Start the containers created above. Starting is deferred to here,
+	// rather than happening as each Docker step installs, so that every
+	// install step has been materialized before anything boots and the
+	// preStart hook has somewhere useful to run. A package that seeds state
+	// its service reads on first boot needs both: the config rendered by its
+	// file steps, and a chance to act before that service starts.
+	if err := p.startServices(cfg, context, runHooks); err != nil {
+		return "", nil, nil, err
+	}
 	// Capture port details for output templates
 	retPorts, err := p.currentPorts(cfg, context)
 	if err != nil {
@@ -582,10 +591,21 @@ func (p Package) validate(cfg Config) error {
 }
 
 func (p Package) startService(cfg Config, context string) error {
+	return p.startServices(cfg, context, true)
+}
+
+// startServices starts the package's services, running the start hooks when
+// runHooks is set. Upgrade installs with hooks disabled, so that seeding work
+// already done for the installed version is not repeated.
+func (p Package) startServices(
+	cfg Config,
+	context string,
+	runHooks bool,
+) error {
 	pkgName := fmt.Sprintf("%s-%s-%s", p.Name, p.Version, context)
 
 	// Run pre-start script
-	if p.PreStartScript != "" {
+	if runHooks && p.PreStartScript != "" {
 		if err := p.runHookScript(cfg, p.PreStartScript); err != nil {
 			return fmt.Errorf("pre-start hook failed: %w", err)
 		}
@@ -658,7 +678,7 @@ func (p Package) startService(cfg Config, context string) error {
 	}
 
 	// Run post-start script
-	if p.PostStartScript != "" {
+	if runHooks && p.PostStartScript != "" {
 		if err := p.runHookScript(cfg, p.PostStartScript); err != nil {
 			p.rollbackStartedServices(startedServices)
 			return fmt.Errorf("post-start hook failed: %w", err)
@@ -1009,18 +1029,12 @@ func (p *PackageInstallStepDocker) install(
 		Ports:         tmpPorts,
 	}
 	if p.PullOnly {
-		if err := svc.pullImage(); err != nil {
-			return err
-		}
-	} else {
-		if err := svc.Create(); err != nil {
-			return err
-		}
-		if err := svc.Start(); err != nil {
-			return err
-		}
+		return svc.pullImage()
 	}
-	return nil
+	// Create the container but leave it stopped. Package.install starts the
+	// package's services once every install step has been materialized, so
+	// that the preStart hook gets to run before any service boots.
+	return svc.Create()
 }
 
 func (p *PackageInstallStepDocker) uninstall(

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -613,6 +613,19 @@ func (p Package) startServices(
 	var startErrors []string
 	startedServices := make([]serviceLifecycle, 0)
 	for _, step := range p.InstallSteps {
+		// Evaluate condition if defined. A step skipped at install time was
+		// never materialized, so its container does not exist and looking it
+		// up here would fail the whole start.
+		if step.Condition != "" {
+			if ok, err := cfg.Template.EvaluateCondition(step.Condition, nil); err != nil {
+				return NewInstallStepConditionError(step.Condition, err)
+			} else if !ok {
+				cfg.Logger.Debug(
+					"skipping start step due to condition: " + step.Condition,
+				)
+				continue
+			}
+		}
 		if step.Docker != nil {
 			if step.Docker.PullOnly {
 				continue

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -195,7 +195,11 @@ func (p Package) install(
 			return "", nil, nil, err
 		}
 	}
-	// Perform install
+	// Perform install. Track the containers created along the way so that a
+	// later failure can remove them again: the pre-flight check above rejects
+	// a container that already exists, so anything left behind by a failed
+	// install would block the retry.
+	var createdSteps []*PackageInstallStepDocker
 	for _, installStep := range p.InstallSteps {
 		// Evaluate condition if defined
 		if installStep.Condition != "" {
@@ -217,13 +221,19 @@ func (p Package) install(
 				stepPorts = registeredPorts[installStep.Docker.ContainerName]
 			}
 			if err := installStep.Docker.install(cfg, pkgName, stepPorts); err != nil {
+				p.removeCreatedContainers(cfg, pkgName, createdSteps)
 				return "", nil, nil, err
+			}
+			if !installStep.Docker.PullOnly {
+				createdSteps = append(createdSteps, installStep.Docker)
 			}
 		} else if installStep.File != nil {
 			if err := installStep.File.install(cfg, pkgName, p.filePath); err != nil {
+				p.removeCreatedContainers(cfg, pkgName, createdSteps)
 				return "", nil, nil, err
 			}
 		} else {
+			p.removeCreatedContainers(cfg, pkgName, createdSteps)
 			return "", nil, nil, ErrNoInstallMethods
 		}
 	}
@@ -234,6 +244,7 @@ func (p Package) install(
 	// its service reads on first boot needs both: the config rendered by its
 	// file steps, and a chance to act before that service starts.
 	if err := p.startServices(cfg, context, runHooks); err != nil {
+		p.removeCreatedContainers(cfg, pkgName, createdSteps)
 		return "", nil, nil, err
 	}
 	// Capture port details for output templates
@@ -588,6 +599,29 @@ func (p Package) validate(cfg Config) error {
 		}
 	}
 	return nil
+}
+
+// removeCreatedContainers removes containers created earlier in the same
+// install, so a failed install leaves nothing behind for the pre-flight check
+// to reject on a retry. Images are kept: they were just pulled, and they are
+// not what blocks a retry. A cleanup failure is logged rather than returned,
+// so it cannot mask the error that triggered the cleanup.
+func (p Package) removeCreatedContainers(
+	cfg Config,
+	pkgName string,
+	steps []*PackageInstallStepDocker,
+) {
+	for _, step := range steps {
+		if err := step.uninstall(cfg, pkgName, true); err != nil {
+			cfg.Logger.Warn(
+				fmt.Sprintf(
+					"failed to remove container %q after a failed install: %s",
+					step.ContainerName,
+					err,
+				),
+			)
+		}
+	}
 }
 
 func (p Package) startService(cfg Config, context string) error {

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -768,6 +768,20 @@ func (p Package) stopService(cfg Config, context string) error {
 	var stopErrors []string
 	stoppedServices := make([]serviceLifecycle, 0)
 	for _, step := range p.InstallSteps {
+		// Evaluate condition if defined. A step skipped at install time was
+		// never materialized, so its container does not exist and looking it
+		// up here would fail the stop for a package that installed cleanly.
+		if step.Condition != "" {
+			if ok, err := cfg.Template.EvaluateCondition(step.Condition, nil); err != nil {
+				p.rollbackStoppedServices(stoppedServices)
+				return NewInstallStepConditionError(step.Condition, err)
+			} else if !ok {
+				cfg.Logger.Debug(
+					"skipping stop step due to condition: " + step.Condition,
+				)
+				continue
+			}
+		}
 		if step.Docker != nil {
 			if step.Docker.PullOnly {
 				continue

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -200,6 +200,12 @@ func (p Package) install(
 	// a container that already exists, so anything left behind by a failed
 	// install would block the retry.
 	var createdSteps []*PackageInstallStepDocker
+	installed := false
+	defer func() {
+		if !installed {
+			p.removeCreatedContainers(cfg, pkgName, createdSteps)
+		}
+	}()
 	for _, installStep := range p.InstallSteps {
 		// Evaluate condition if defined
 		if installStep.Condition != "" {
@@ -221,7 +227,6 @@ func (p Package) install(
 				stepPorts = registeredPorts[installStep.Docker.ContainerName]
 			}
 			if err := installStep.Docker.install(cfg, pkgName, stepPorts); err != nil {
-				p.removeCreatedContainers(cfg, pkgName, createdSteps)
 				return "", nil, nil, err
 			}
 			if !installStep.Docker.PullOnly {
@@ -229,11 +234,9 @@ func (p Package) install(
 			}
 		} else if installStep.File != nil {
 			if err := installStep.File.install(cfg, pkgName, p.filePath); err != nil {
-				p.removeCreatedContainers(cfg, pkgName, createdSteps)
 				return "", nil, nil, err
 			}
 		} else {
-			p.removeCreatedContainers(cfg, pkgName, createdSteps)
 			return "", nil, nil, ErrNoInstallMethods
 		}
 	}
@@ -244,7 +247,6 @@ func (p Package) install(
 	// its service reads on first boot needs both: the config rendered by its
 	// file steps, and a chance to act before that service starts.
 	if err := p.startServices(cfg, context, runHooks); err != nil {
-		p.removeCreatedContainers(cfg, pkgName, createdSteps)
 		return "", nil, nil, err
 	}
 	// Capture port details for output templates
@@ -276,6 +278,7 @@ func (p Package) install(
 		}
 		retNotes = tmpNotes
 	}
+	installed = true
 	return retNotes, retOutputs, retPorts, nil
 }
 
@@ -652,6 +655,7 @@ func (p Package) startServices(
 		// up here would fail the whole start.
 		if step.Condition != "" {
 			if ok, err := cfg.Template.EvaluateCondition(step.Condition, nil); err != nil {
+				p.rollbackStartedServices(startedServices)
 				return NewInstallStepConditionError(step.Condition, err)
 			} else if !ok {
 				cfg.Logger.Debug(
@@ -890,6 +894,15 @@ func (p Package) services(
 	var ret []*DockerService
 	pkgName := fmt.Sprintf("%s-%s-%s", p.Name, p.Version, context)
 	for _, step := range p.InstallSteps {
+		// Evaluate condition if defined. A step skipped at install time has
+		// no container, so looking one up would fail the whole call.
+		if step.Condition != "" {
+			if ok, err := cfg.Template.EvaluateCondition(step.Condition, nil); err != nil {
+				return ret, NewInstallStepConditionError(step.Condition, err)
+			} else if !ok {
+				continue
+			}
+		}
 		if step.Docker != nil {
 			if step.Docker.PullOnly {
 				continue

--- a/pkgmgr/package_install_hooks_test.go
+++ b/pkgmgr/package_install_hooks_test.go
@@ -322,3 +322,73 @@ func TestStartServices_RollsBackWhenConditionErrors(t *testing.T) {
 		t.Fatal("expected the already-started service to be rolled back")
 	}
 }
+
+// TestConditionNeedsPackageTemplateVars pins the trap behind the condition
+// filtering in services(): a template variable that is absent renders as
+// false with no error, so a caller that passes a config without the
+// package-specific variables does not fail loudly - it silently decides the
+// condition is false and skips the step. Every caller of services() therefore
+// has to build those variables first, or info and logs would quietly omit a
+// service whose condition is actually true.
+func TestConditionNeedsPackageTemplateVars(t *testing.T) {
+	pkg := Package{
+		Name:    "mypkg",
+		Version: "1.0.0",
+		Options: []PackageOption{
+			{Name: "extra", Default: true},
+		},
+	}
+	base := Config{
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DataDir:  t.TempDir(),
+		Template: NewTemplate(nil),
+	}
+
+	cfg := pkg.withPackageTemplateVars(base, "testctx", pkg.defaultOpts())
+	ok, err := cfg.Template.EvaluateCondition(`.Package.Options.extra`, nil)
+	if err != nil {
+		t.Fatalf("unexpected error with package template vars: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected .Package.Options.extra to be true with package template vars")
+	}
+
+	ok, err = base.Template.EvaluateCondition(`.Package.Options.extra`, nil)
+	if err != nil {
+		t.Fatalf("unexpected error without package template vars: %v", err)
+	}
+	if ok {
+		t.Fatal("expected the condition to evaluate false without package template vars")
+	}
+}
+
+// TestServices_SkipsStepsWithFalseCondition verifies that services() honors
+// install-step conditions, so a step that was never materialized is not
+// looked up as a container.
+func TestServices_SkipsStepsWithFalseCondition(t *testing.T) {
+	pkg := Package{
+		Name:    "mypkg",
+		Version: "1.0.0",
+		InstallSteps: []PackageInstallStep{
+			{
+				Condition: `eq "a" "b"`,
+				Docker: &PackageInstallStepDocker{
+					ContainerName: "skipped",
+					Image:         "alpine:3.20",
+				},
+			},
+		},
+	}
+	cfg := Config{
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Template: NewTemplate(nil),
+	}
+
+	services, err := pkg.services(cfg, "testctx")
+	if err != nil {
+		t.Fatalf("services failed: %v", err)
+	}
+	if len(services) != 0 {
+		t.Fatalf("expected the condition-skipped step to yield no services, got %d", len(services))
+	}
+}

--- a/pkgmgr/package_install_hooks_test.go
+++ b/pkgmgr/package_install_hooks_test.go
@@ -210,3 +210,62 @@ func TestStartService_PreStartHookRunsBeforeContainerStart(t *testing.T) {
 		t.Fatalf("unexpected order: got %v, want %v", got, want)
 	}
 }
+
+// TestStartServices_SkipsStepsWithFalseCondition verifies that starting a
+// package's services honors the same install-step conditions the install loop
+// applies. A step whose condition evaluates false is never materialized, so
+// its container does not exist and inspecting it fails with
+// ErrContainerNotExists - which would otherwise fail the whole operation.
+func TestStartServices_SkipsStepsWithFalseCondition(t *testing.T) {
+	origNewServiceFromContainerName := newServiceFromContainerName
+	t.Cleanup(func() {
+		newServiceFromContainerName = origNewServiceFromContainerName
+	})
+
+	created := &fakeServiceLifecycle{}
+	var askedFor []string
+	newServiceFromContainerName = func(containerName string, logger *slog.Logger) (serviceLifecycle, error) {
+		askedFor = append(askedFor, containerName)
+		if containerName == "mypkg-1.0.0-testctx-created" {
+			return created, nil
+		}
+		// Matches production behavior for a container that was never created.
+		return nil, ErrContainerNotExists
+	}
+
+	cfg := Config{
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Template: NewTemplate(nil),
+	}
+	pkg := Package{
+		Name:    "mypkg",
+		Version: "1.0.0",
+		InstallSteps: []PackageInstallStep{
+			{
+				Docker: &PackageInstallStepDocker{
+					ContainerName: "created",
+					Image:         "alpine:3.20",
+				},
+			},
+			{
+				Condition: `eq "a" "b"`,
+				Docker: &PackageInstallStepDocker{
+					ContainerName: "skipped",
+					Image:         "alpine:3.20",
+				},
+			},
+		},
+	}
+
+	if err := pkg.startService(cfg, "testctx"); err != nil {
+		t.Fatalf("startService failed: %v", err)
+	}
+	if !created.started {
+		t.Fatal("expected the materialized container to be started")
+	}
+	for _, name := range askedFor {
+		if name == "mypkg-1.0.0-testctx-skipped" {
+			t.Fatal("expected the condition-skipped step to not be looked up")
+		}
+	}
+}

--- a/pkgmgr/package_install_hooks_test.go
+++ b/pkgmgr/package_install_hooks_test.go
@@ -269,3 +269,56 @@ func TestStartServices_SkipsStepsWithFalseCondition(t *testing.T) {
 		}
 	}
 }
+
+// TestStartServices_RollsBackWhenConditionErrors verifies that a condition
+// that fails to evaluate rolls back services already started in the same
+// call, rather than leaving a partial startup running.
+func TestStartServices_RollsBackWhenConditionErrors(t *testing.T) {
+	origNewServiceFromContainerName := newServiceFromContainerName
+	t.Cleanup(func() {
+		newServiceFromContainerName = origNewServiceFromContainerName
+	})
+
+	started := &fakeServiceLifecycle{}
+	newServiceFromContainerName = func(containerName string, logger *slog.Logger) (serviceLifecycle, error) {
+		if containerName == "mypkg-1.0.0-testctx-started" {
+			return started, nil
+		}
+		return nil, ErrContainerNotExists
+	}
+
+	cfg := Config{
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Template: NewTemplate(nil),
+	}
+	pkg := Package{
+		Name:    "mypkg",
+		Version: "1.0.0",
+		InstallSteps: []PackageInstallStep{
+			{
+				Docker: &PackageInstallStepDocker{
+					ContainerName: "started",
+					Image:         "alpine:3.20",
+				},
+			},
+			{
+				// eq with a single argument fails at evaluation time.
+				Condition: `eq "a"`,
+				Docker: &PackageInstallStepDocker{
+					ContainerName: "second",
+					Image:         "alpine:3.20",
+				},
+			},
+		},
+	}
+
+	if err := pkg.startService(cfg, "testctx"); err == nil {
+		t.Fatal("expected startService to fail when a condition cannot be evaluated")
+	}
+	if !started.started {
+		t.Fatal("expected the first service to have been started")
+	}
+	if !started.stopped {
+		t.Fatal("expected the already-started service to be rolled back")
+	}
+}

--- a/pkgmgr/package_install_hooks_test.go
+++ b/pkgmgr/package_install_hooks_test.go
@@ -1,0 +1,212 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkgmgr
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeHookScript writes a /bin/sh script that appends label to hookLog and
+// returns its path. runHookScript renders the script value and runs it with
+// `/bin/sh -c`, so a path is a valid hook body.
+func writeHookScript(t *testing.T, dir, name, hookLog, label, extra string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	body := "#!/bin/sh\n" + extra + "echo '" + label + "' >> " + hookLog + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("failed to write %s: %v", name, err)
+	}
+	return path
+}
+
+func readHookLog(t *testing.T, hookLog string) []string {
+	t.Helper()
+	contents, err := os.ReadFile(hookLog)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("failed to read hook log: %v", err)
+	}
+	return strings.Fields(strings.TrimSpace(string(contents)))
+}
+
+// TestInstall_RunsPreStartHookAfterInstallSteps verifies that installing a
+// package runs its preStart hook, and runs it once the install steps have
+// been materialized.
+//
+// `cardano-up install` creates and starts a package's containers, so a
+// package that has to seed state its service reads on first boot - Dolos
+// bootstrapping storage from a Mithril snapshot, for example - needs a hook
+// that runs during install but after the install steps that render its
+// config. preInstall is too early: it runs before any install step, so a
+// config rendered by a `file` step does not exist yet.
+func TestInstall_RunsPreStartHookAfterInstallSteps(t *testing.T) {
+	tmpDir := t.TempDir()
+	hookLog := filepath.Join(tmpDir, "hooks.log")
+
+	pkgName := "mypkg-1.0.0-testctx"
+	renderedConfig := filepath.Join(tmpDir, pkgName, "daemon.toml")
+
+	// The preStart hook fails unless the file install step has already
+	// rendered its config, which is what makes this hook usable for seeding.
+	preStart := writeHookScript(
+		t, tmpDir, "prestart.sh", hookLog, "prestart",
+		"test -f "+renderedConfig+" || exit 1\n",
+	)
+	preInstall := writeHookScript(t, tmpDir, "preinstall.sh", hookLog, "preinstall", "")
+	postInstall := writeHookScript(t, tmpDir, "postinstall.sh", hookLog, "postinstall", "")
+
+	cfg := Config{
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		CacheDir: tmpDir,
+		DataDir:  tmpDir,
+		BinDir:   tmpDir,
+		Template: NewTemplate(nil),
+	}
+	pkg := Package{
+		Name:              "mypkg",
+		Version:           "1.0.0",
+		PreInstallScript:  preInstall,
+		PreStartScript:    preStart,
+		PostInstallScript: postInstall,
+		InstallSteps: []PackageInstallStep{
+			{
+				File: &PackageInstallStepFile{
+					Filename: "daemon.toml",
+					Content:  "seeded = true\n",
+				},
+			},
+		},
+	}
+
+	if _, _, _, err := pkg.install(cfg, "testctx", nil, true, nil); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	got := readHookLog(t, hookLog)
+	want := []string{"preinstall", "prestart", "postinstall"}
+	if len(got) != len(want) {
+		t.Fatalf("unexpected hook order: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("unexpected hook order: got %v, want %v", got, want)
+		}
+	}
+}
+
+// TestInstall_SkipsPreStartHookWhenHooksDisabled verifies that the preStart
+// hook honors the runHooks flag, which upgrade sets to false so that seeding
+// work already done for the installed version is not repeated.
+func TestInstall_SkipsPreStartHookWhenHooksDisabled(t *testing.T) {
+	tmpDir := t.TempDir()
+	hookLog := filepath.Join(tmpDir, "hooks.log")
+	preStart := writeHookScript(t, tmpDir, "prestart.sh", hookLog, "prestart", "")
+
+	cfg := Config{
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		CacheDir: tmpDir,
+		DataDir:  tmpDir,
+		BinDir:   tmpDir,
+		Template: NewTemplate(nil),
+	}
+	pkg := Package{
+		Name:           "mypkg",
+		Version:        "1.0.0",
+		PreStartScript: preStart,
+		InstallSteps:   []PackageInstallStep{},
+	}
+
+	if _, _, _, err := pkg.install(cfg, "testctx", nil, false, nil); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	if got := readHookLog(t, hookLog); len(got) != 0 {
+		t.Fatalf("expected no hooks to run with runHooks=false, got %v", got)
+	}
+}
+
+// TestStartService_PreStartHookRunsBeforeContainerStart verifies the ordering
+// the seeding use case depends on: the preStart hook completes before any
+// container is started. A hook that seeds storage is useless if the service
+// that reads that storage has already booted.
+func TestStartService_PreStartHookRunsBeforeContainerStart(t *testing.T) {
+	origNewServiceFromContainerName := newServiceFromContainerName
+	t.Cleanup(func() {
+		newServiceFromContainerName = origNewServiceFromContainerName
+	})
+
+	tmpDir := t.TempDir()
+	hookLog := filepath.Join(tmpDir, "hooks.log")
+	preStart := writeHookScript(t, tmpDir, "prestart.sh", hookLog, "prestart", "")
+
+	svc := &fakeServiceLifecycle{
+		onStart: func() {
+			f, err := os.OpenFile(
+				hookLog,
+				os.O_APPEND|os.O_CREATE|os.O_WRONLY,
+				0o644,
+			)
+			if err != nil {
+				t.Errorf("failed to record start: %v", err)
+				return
+			}
+			defer f.Close()
+			if _, err := f.WriteString("container-start\n"); err != nil {
+				t.Errorf("failed to record start: %v", err)
+			}
+		},
+	}
+	newServiceFromContainerName = func(containerName string, logger *slog.Logger) (serviceLifecycle, error) {
+		return svc, nil
+	}
+
+	cfg := Config{
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Template: NewTemplate(nil),
+	}
+	pkg := Package{
+		Name:           "mypkg",
+		Version:        "1.0.0",
+		PreStartScript: preStart,
+		InstallSteps: []PackageInstallStep{
+			{
+				Docker: &PackageInstallStepDocker{
+					ContainerName: "svc",
+					Image:         "alpine:3.20",
+				},
+			},
+		},
+	}
+
+	if err := pkg.startService(cfg, "testctx"); err != nil {
+		t.Fatalf("startService failed: %v", err)
+	}
+	if !svc.started {
+		t.Fatal("expected the container to be started")
+	}
+
+	got := readHookLog(t, hookLog)
+	want := []string{"prestart", "container-start"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("unexpected order: got %v, want %v", got, want)
+	}
+}

--- a/pkgmgr/package_install_hooks_test.go
+++ b/pkgmgr/package_install_hooks_test.go
@@ -392,3 +392,109 @@ func TestServices_SkipsStepsWithFalseCondition(t *testing.T) {
 		t.Fatalf("expected the condition-skipped step to yield no services, got %d", len(services))
 	}
 }
+
+// TestStopService_SkipsStepsWithFalseCondition verifies that stopping a
+// package honors install-step conditions, so the stop path does not look up a
+// container that was never materialized. Without this, the first
+// `cardano-up down` fails for a package that installs successfully.
+func TestStopService_SkipsStepsWithFalseCondition(t *testing.T) {
+	origNewServiceFromContainerName := newServiceFromContainerName
+	t.Cleanup(func() {
+		newServiceFromContainerName = origNewServiceFromContainerName
+	})
+
+	created := &fakeServiceLifecycle{running: true}
+	var askedFor []string
+	newServiceFromContainerName = func(
+		containerName string,
+		logger *slog.Logger,
+	) (serviceLifecycle, error) {
+		askedFor = append(askedFor, containerName)
+		if containerName == "mypkg-1.0.0-testctx-created" {
+			return created, nil
+		}
+		return nil, ErrContainerNotExists
+	}
+
+	cfg := Config{
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Template: NewTemplate(nil),
+	}
+	pkg := Package{
+		Name:    "mypkg",
+		Version: "1.0.0",
+		InstallSteps: []PackageInstallStep{
+			{
+				Docker: &PackageInstallStepDocker{
+					ContainerName: "created",
+					Image:         "alpine:3.20",
+				},
+			},
+			{
+				Condition: `eq "a" "b"`,
+				Docker: &PackageInstallStepDocker{
+					ContainerName: "skipped",
+					Image:         "alpine:3.20",
+				},
+			},
+		},
+	}
+
+	if err := pkg.stopService(cfg, "testctx"); err != nil {
+		t.Fatalf("stopService failed: %v", err)
+	}
+	if !created.stopped {
+		t.Fatal("expected the materialized service to be stopped")
+	}
+	for _, name := range askedFor {
+		if name == "mypkg-1.0.0-testctx-skipped" {
+			t.Fatal("expected the condition-skipped step to not be looked up")
+		}
+	}
+}
+
+// TestInstalledPkgConfig_SuppliesConditionVars verifies that the config handed
+// to condition-aware lifecycle calls carries the installed package's options.
+// Uninstall, deactivate and stop all evaluate install-step conditions, and an
+// absent variable reads as false without error - so passing the bare manager
+// config makes uninstall skip a step whose container does exist, orphaning it
+// while the installed-package record is removed.
+func TestInstalledPkgConfig_SuppliesConditionVars(t *testing.T) {
+	pkg := Package{
+		Name:    "mypkg",
+		Version: "1.0.0",
+		Options: []PackageOption{
+			{Name: "extra", Default: true},
+		},
+	}
+	pm := &PackageManager{
+		config: Config{
+			Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+			DataDir:  t.TempDir(),
+			Template: NewTemplate(nil),
+		},
+	}
+	installedPkg := InstalledPackage{
+		Package: pkg,
+		Context: "testctx",
+		Options: map[string]bool{"extra": true},
+	}
+
+	cfg := pm.installedPkgConfig(installedPkg, "testctx")
+	ok, err := cfg.Template.EvaluateCondition(`.Package.Options.extra`, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected the installed package's options to be visible to the condition")
+	}
+
+	// The bare manager config is what caused the orphaning: silently false.
+	ok, err = pm.config.Template.EvaluateCondition(`.Package.Options.extra`, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected the bare manager config to evaluate the condition false")
+	}
+}

--- a/pkgmgr/package_test.go
+++ b/pkgmgr/package_test.go
@@ -53,6 +53,11 @@ type fakeServiceLifecycle struct {
 	// Stop() has been called - simulates a status check that fails right
 	// after an attempt to stop the container.
 	runningErrAfterStop error
+
+	// onStart, if set, is called by Start() before the service is marked
+	// running. Lets a test observe when a container start happens relative
+	// to hook execution.
+	onStart func()
 }
 
 func (f *fakeServiceLifecycle) Running() (bool, error) {
@@ -63,6 +68,9 @@ func (f *fakeServiceLifecycle) Running() (bool, error) {
 }
 
 func (f *fakeServiceLifecycle) Start() error {
+	if f.onStart != nil {
+		f.onStart()
+	}
 	f.started = true
 	f.running = true
 	return nil

--- a/pkgmgr/pkgmgr.go
+++ b/pkgmgr/pkgmgr.go
@@ -482,7 +482,15 @@ func (p *PackageManager) Logs(
 	if !foundPackage {
 		return NewPackageNotInstalledError(pkgName, contextName)
 	}
-	services, err := logsPkg.Package.services(p.config, contextName)
+	// Build the package-specific template variables first: install-step
+	// conditions can reference them, and an absent variable renders as false
+	// rather than erroring, which would silently drop a service here.
+	logsCfg := logsPkg.Package.withPackageTemplateVars(
+		p.config,
+		contextName,
+		logsPkg.Options,
+	)
+	services, err := logsPkg.Package.services(logsCfg, contextName)
 	if err != nil {
 		return err
 	}
@@ -532,7 +540,12 @@ func (p *PackageManager) Info(pkgs ...string) error {
 			)
 		}
 		// Gather package services
-		services, err := infoPkg.Package.services(p.config, infoPkg.Context)
+		infoCfg := infoPkg.Package.withPackageTemplateVars(
+			p.config,
+			infoPkg.Context,
+			infoPkg.Options,
+		)
+		services, err := infoPkg.Package.services(infoCfg, infoPkg.Context)
 		if err != nil {
 			return err
 		}

--- a/pkgmgr/pkgmgr.go
+++ b/pkgmgr/pkgmgr.go
@@ -120,7 +120,7 @@ func (p *PackageManager) Up() error {
 	contextName, _ := p.effectiveContext()
 	var errs []error
 	for idx := range p.state.InstalledPackages {
-		installedPkg := &(p.state.InstalledPackages[idx])
+		installedPkg := &p.state.InstalledPackages[idx]
 		if installedPkg.Context != contextName {
 			continue
 		}

--- a/pkgmgr/pkgmgr.go
+++ b/pkgmgr/pkgmgr.go
@@ -180,11 +180,28 @@ func (p *PackageManager) refreshInstalledPackageRuntime(
 	return nil
 }
 
+// installedPkgConfig returns the manager config with the package-scoped
+// template variables that an install-step condition may reference. Every
+// condition-aware lifecycle call needs these: an absent variable renders as
+// false with no error, so without them a condition silently reads false and
+// the step is skipped rather than failing loudly.
+func (p *PackageManager) installedPkgConfig(
+	installedPkg InstalledPackage,
+	context string,
+) Config {
+	return installedPkg.Package.withPackageTemplateVars(
+		p.config,
+		context,
+		installedPkg.Options,
+	)
+}
+
 func (p *PackageManager) Down() error {
 	// Find installed packages
 	installedPackages := p.InstalledPackages()
 	for _, tmpPackage := range installedPackages {
-		err := tmpPackage.Package.stopService(p.config, tmpPackage.Context)
+		cfg := p.installedPkgConfig(tmpPackage, tmpPackage.Context)
+		err := tmpPackage.Package.stopService(cfg, tmpPackage.Context)
 		if err != nil {
 			return err
 		}
@@ -277,7 +294,12 @@ func (p *PackageManager) Install(pkgs ...string) error {
 			sb.WriteString("\n")
 		}
 		// Activate package
-		if err := installPkg.Install.activate(p.config, contextName); err != nil {
+		activateCfg := installPkg.Install.withPackageTemplateVars(
+			p.config,
+			contextName,
+			tmpPkgOpts,
+		)
+		if err := installPkg.Install.activate(activateCfg, contextName); err != nil {
 			p.config.Logger.Warn(
 				fmt.Sprintf("failed to activate package: %s", err),
 			)
@@ -328,7 +350,12 @@ func (p *PackageManager) Upgrade(pkgs ...string) error {
 		pkgOpts := upgradePkg.Installed.Options
 		registeredPorts := p.registeredPorts(contextName, upgradePkg.Installed.Package.Name)
 		// Deactivate old package
-		if err := upgradePkg.Installed.Package.deactivate(p.config, contextName); err != nil {
+		deactivateCfg := upgradePkg.Installed.Package.withPackageTemplateVars(
+			p.config,
+			contextName,
+			pkgOpts,
+		)
+		if err := upgradePkg.Installed.Package.deactivate(deactivateCfg, contextName); err != nil {
 			p.config.Logger.Warn(
 				fmt.Sprintf("failed to deactivate package: %s", err),
 			)
@@ -377,7 +404,12 @@ func (p *PackageManager) Upgrade(pkgs ...string) error {
 			return err
 		}
 		// Activate new package
-		if err := upgradePkg.Upgrade.activate(p.config, contextName); err != nil {
+		activateCfg := upgradePkg.Upgrade.withPackageTemplateVars(
+			p.config,
+			contextName,
+			pkgOpts,
+		)
+		if err := upgradePkg.Upgrade.activate(activateCfg, contextName); err != nil {
 			p.config.Logger.Warn(
 				fmt.Sprintf("failed to activate package: %s", err),
 			)
@@ -437,7 +469,8 @@ func (p *PackageManager) Uninstall(
 	}
 	for _, uninstallPkg := range uninstallPkgs {
 		// Deactivate package
-		if err := uninstallPkg.Package.deactivate(p.config, contextName); err != nil {
+		deactivateCfg := p.installedPkgConfig(uninstallPkg, contextName)
+		if err := uninstallPkg.Package.deactivate(deactivateCfg, contextName); err != nil {
 			p.config.Logger.Warn(
 				fmt.Sprintf("failed to deactivate package: %s", err),
 			)
@@ -618,7 +651,8 @@ func (p *PackageManager) uninstallPackage(
 	runHooks bool,
 ) error {
 	// Uninstall package
-	if err := uninstallPkg.Package.uninstall(p.config, uninstallPkg.Context, keepData, runHooks); err != nil {
+	uninstallCfg := p.installedPkgConfig(uninstallPkg, uninstallPkg.Context)
+	if err := uninstallPkg.Package.uninstall(uninstallCfg, uninstallPkg.Context, keepData, runHooks); err != nil {
 		return err
 	}
 	// Remove package from installed packages
@@ -702,7 +736,8 @@ func (p *PackageManager) SetActiveContext(name string) error {
 	// Deactivate packages in current context
 	activeContextName, _ := p.ActiveContext()
 	for _, pkg := range p.InstalledPackages() {
-		if err := pkg.Package.deactivate(p.config, activeContextName); err != nil {
+		deactivateCfg := p.installedPkgConfig(pkg, activeContextName)
+		if err := pkg.Package.deactivate(deactivateCfg, activeContextName); err != nil {
 			p.config.Logger.Warn(
 				fmt.Sprintf("failed to deactivate package: %s", err),
 			)
@@ -716,7 +751,8 @@ func (p *PackageManager) SetActiveContext(name string) error {
 	p.initTemplate()
 	// Activate packages in new context
 	for _, pkg := range p.InstalledPackages() {
-		if err := pkg.Package.activate(p.config, name); err != nil {
+		activateCfg := p.installedPkgConfig(pkg, name)
+		if err := pkg.Package.activate(activateCfg, name); err != nil {
 			p.config.Logger.Warn(
 				fmt.Sprintf("failed to activate package: %s", err),
 			)

--- a/pkgmgr/state.go
+++ b/pkgmgr/state.go
@@ -123,7 +123,7 @@ func (s *State) saveFile(filename string, src any) error {
 }
 
 func (s *State) loadContexts() error {
-	if err := s.loadFile(contextsFilename, &(s.Contexts)); err != nil {
+	if err := s.loadFile(contextsFilename, &s.Contexts); err != nil {
 		return err
 	}
 	if len(s.Contexts) == 0 {
@@ -133,11 +133,11 @@ func (s *State) loadContexts() error {
 }
 
 func (s *State) saveContexts() error {
-	return s.saveFile(contextsFilename, &(s.Contexts))
+	return s.saveFile(contextsFilename, &s.Contexts)
 }
 
 func (s *State) loadActiveContext() error {
-	if err := s.loadFile(activeContextFilename, &(s.ActiveContext)); err != nil {
+	if err := s.loadFile(activeContextFilename, &s.ActiveContext); err != nil {
 		return err
 	}
 	if s.ActiveContext == "" {
@@ -147,19 +147,19 @@ func (s *State) loadActiveContext() error {
 }
 
 func (s *State) saveActiveContext() error {
-	return s.saveFile(activeContextFilename, &(s.ActiveContext))
+	return s.saveFile(activeContextFilename, &s.ActiveContext)
 }
 
 func (s *State) loadInstalledPackages() error {
-	return s.loadFile(installedPackagesFilename, &(s.InstalledPackages))
+	return s.loadFile(installedPackagesFilename, &s.InstalledPackages)
 }
 
 func (s *State) saveInstalledPackages() error {
-	return s.saveFile(installedPackagesFilename, &(s.InstalledPackages))
+	return s.saveFile(installedPackagesFilename, &s.InstalledPackages)
 }
 
 func (s *State) loadPortRegistry() error {
-	if err := s.loadFile(portRegistryFilename, &(s.PortRegistry)); err != nil {
+	if err := s.loadFile(portRegistryFilename, &s.PortRegistry); err != nil {
 		return err
 	}
 	if s.PortRegistry == nil {
@@ -169,5 +169,5 @@ func (s *State) loadPortRegistry() error {
 }
 
 func (s *State) savePortRegistry() error {
-	return s.saveFile(portRegistryFilename, &(s.PortRegistry))
+	return s.saveFile(portRegistryFilename, &s.PortRegistry)
 }


### PR DESCRIPTION
Closes #243 (first of two changes; the Dolos package change follows once this ships in a release).

## Problem

`install` created and started each Docker step's container as that step ran (`pkgmgr/package.go`, `PackageInstallStepDocker.install`), so `preStartScript` only ever ran from `up` via `startService`.

That left no usable hook for a package that has to seed state its service reads on first boot:

- `preInstallScript` runs before any install step, so a config rendered by a `file` step does not exist yet.
- `preStartScript` runs too late — by the first `up` the service has already started and populated its own state.

This is what blocks #243: `dolos bootstrap mithril` reads the aggregator, genesis key and storage path from the `daemon.toml` that the package renders with a `file` step, and it has to run before the daemon boots. `preStartScript` has been in the package schema since the hook was added, but no package uses it.

## Change

Create containers during the install steps and start them afterwards, through a shared path that runs the start hooks. `startService` keeps its signature and delegates to `startServices(cfg, context, runHooks)`; hooks stay gated on `runHooks`, which `upgrade` sets to `false`.

Ordering on install is now: `preInstall` → install steps → `preStart` → start containers → `postStart` → ports/outputs → `postInstall`. Containers start marginally later than before, after all steps are materialized rather than mid-loop.

## Tests

`pkgmgr/package_install_hooks_test.go`:

- `TestInstall_RunsPreStartHookAfterInstallSteps` — the hook runs on the install path, and only once the `file` step has rendered its config (the hook fails if the file is missing). Fails on `main` with `got [preinstall postinstall]`.
- `TestInstall_SkipsPreStartHookWhenHooksDisabled` — `runHooks=false` still skips it, preserving upgrade behavior.
- `TestStartService_PreStartHookRunsBeforeContainerStart` — the hook completes before any container start, via the existing `newServiceFromContainerName` seam.

## Validation

- `go test ./...`, `go test -race ./...`, `golangci-lint run ./...` (0 issues), `gofmt` clean.
- Real install with the built binary against an isolated `HOME` and a local `REGISTRY_DIR`, using a probe package whose hook records what it observes:

| | `config-rendered` | `container-running-at-prestart` |
|---|---|---|
| patched | `yes` | `no` |
| `main` | hook never ran | hook never ran |

- `install` → `down` → `up` cycle checked: container runs after install, stops on `down`, restarts on `up`, and the hook runs on each start.

Note the hook runs on **every** start, not just the first — so hooks of this kind must be idempotent. The Dolos follow-up relies on `dolos bootstrap --skip-if-data` for that; without the flag bootstrap exits 1 with `existing data detected in storage` once the store has a cursor.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run preStart before any service starts on install and clean up containers from failed installs so retries aren’t blocked. Also apply install-step conditions and package-scoped template vars across start/stop/activate/deactivate/info/logs to prevent silent drops and orphaned containers.

- Install order: preInstall → install steps (create/pull only) → preStart → start containers → postStart → ports/outputs → postInstall; starting flows through startServices(runHooks).
- Cleanup: on any failure after container creation (start/hooks/ports/outputs/notes), remove only containers created by this install; keep images; log cleanup errors.
- Conditions: startService, stopService, and services() skip steps whose condition is false; both start and stop roll back already-started/stopped services if a condition fails to evaluate.
- Template vars: all lifecycle calls that evaluate conditions pass package template vars; `info` and `logs` no longer drop services whose conditions reference `.Package`.

- Required migration: Make preStartScript idempotent; it runs on every start, including the first start after install.

<sup>Written for commit 22f055beb3ed91d04f0b1928b5ca1cad067cd323. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up/pull/578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package installation so containers are prepared before services start.
  * Ensured pre-start and post-start hooks run in the correct order.
  * Prevented pre-start hooks from running during upgrade flows when hooks are disabled.
  * Ensured pre-start hooks finish before services and containers are started.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->