### PR TITLE
style(pkgmgr): drop redundant parens flagged by gofumpt

### DIFF
--- a/pkgmgr/pkgmgr.go
+++ b/pkgmgr/pkgmgr.go
@@ -120,7 +120,7 @@ func (p *PackageManager) Up() error {
 	contextName, _ := p.effectiveContext()
 	var errs []error
 	for idx := range p.state.InstalledPackages {
-		installedPkg := &(p.state.InstalledPackages[idx])
+		installedPkg := &p.state.InstalledPackages[idx]
 		if installedPkg.Context != contextName {
 			continue
 		}

--- a/pkgmgr/state.go
+++ b/pkgmgr/state.go
@@ -123,7 +123,7 @@ func (s *State) saveFile(filename string, src any) error {
 }
 
 func (s *State) loadContexts() error {
-	if err := s.loadFile(contextsFilename, &(s.Contexts)); err != nil {
+	if err := s.loadFile(contextsFilename, &s.Contexts); err != nil {
 		return err
 	}
 	if len(s.Contexts) == 0 {
@@ -133,11 +133,11 @@ func (s *State) loadContexts() error {
 }
 
 func (s *State) saveContexts() error {
-	return s.saveFile(contextsFilename, &(s.Contexts))
+	return s.saveFile(contextsFilename, &s.Contexts)
 }
 
 func (s *State) loadActiveContext() error {
-	if err := s.loadFile(activeContextFilename, &(s.ActiveContext)); err != nil {
+	if err := s.loadFile(activeContextFilename, &s.ActiveContext); err != nil {
 		return err
 	}
 	if s.ActiveContext == "" {
@@ -147,19 +147,19 @@ func (s *State) loadActiveContext() error {
 }
 
 func (s *State) saveActiveContext() error {
-	return s.saveFile(activeContextFilename, &(s.ActiveContext))
+	return s.saveFile(activeContextFilename, &s.ActiveContext)
 }
 
 func (s *State) loadInstalledPackages() error {
-	return s.loadFile(installedPackagesFilename, &(s.InstalledPackages))
+	return s.loadFile(installedPackagesFilename, &s.InstalledPackages)
 }
 
 func (s *State) saveInstalledPackages() error {
-	return s.saveFile(installedPackagesFilename, &(s.InstalledPackages))
+	return s.saveFile(installedPackagesFilename, &s.InstalledPackages)
 }
 
 func (s *State) loadPortRegistry() error {
-	if err := s.loadFile(portRegistryFilename, &(s.PortRegistry)); err != nil {
+	if err := s.loadFile(portRegistryFilename, &s.PortRegistry); err != nil {
 		return err
 	}
 	if s.PortRegistry == nil {
@@ -169,5 +169,5 @@ func (s *State) loadPortRegistry() error {
 }
 
 func (s *State) savePortRegistry() error {
-	return s.saveFile(portRegistryFilename, &(s.PortRegistry))
+	return s.saveFile(portRegistryFilename, &s.PortRegistry)
 }


### PR DESCRIPTION
Unblocks CI on `main`. Both open pull requests (#577, #578) currently fail `lint` on these two lines, neither of which they touch.

## Cause

`golangci-lint-action` is unpinned, so CI resolved **v2.13.1** — released today, 2026-08-20T14:28:34Z. Its bundled gofumpt flags `&(x)` where `&x` will do:

```
pkgmgr/pkgmgr.go:123:1: File is not properly formatted (gofumpt)
                installedPkg := &(p.state.InstalledPackages[idx])
pkgmgr/state.go:126:1: File is not properly formatted (gofumpt)
        if err := s.loadFile(contextsFilename, &(s.Contexts)); err != nil {
```

Both sites have been there for months. `main`'s last green `golangci-lint` run predates the release, which is why this surfaced on a PR rather than on `main`.

## Verification

Reproduced on clean `origin/main` at `7ddeba7` with the same v2.13.1 binary CI installs — identical 2 findings, no local changes. After this commit, v2.13.1 reports `0 issues.` and `go test ./...` passes.

Scoped to the two files `lint` actually fails on. `.golangci.yml` sets `run.tests: false`, so the `0755` → `0o755` findings the formatter also reports across `_test.go` files are not part of what CI gates on, and are left alone to keep this diff reviewable.

## Note

This is base-branch drift, not a code change: the unpinned action will keep picking up new formatter releases. Worth deciding separately whether to pin `golangci-lint-action` or accept the float.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops redundant address-of parentheses flagged by `gofumpt` to unblock CI after `golangci-lint` v2.13.1. Previously CI accepted `&(x)`; the new formatter requires `&x`. No runtime behavior changes.

- Scope: strictly formatting in `pkgmgr/pkgmgr.go` and `pkgmgr/state.go`; no logic changes.
- Verification: `golangci-lint` v2.13.1 reports 0 issues; `go test ./...` passes. `_test.go` nits are untouched because `.golangci.yml` sets `run.tests: false`.
- Note: CI uses unpinned `golangci-lint-action` and pulled v2.13.1; consider pinning in a follow-up.

<sup>Written for commit fb40fd6e18e1114860a5a541e10a25269f6b475e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up/pull/579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

