### PR TITLE
fix(pkgmgr): report whether Start() actually started the container

### DIFF
--- a/pkgmgr/docker.go
+++ b/pkgmgr/docker.go
@@ -104,26 +104,39 @@ func (d *DockerService) Running() (bool, error) {
 	return container.State.Running, nil
 }
 
-func (d *DockerService) Start() error {
+// Start starts the container if it is not already running. The returned bool
+// reports whether this call actually issued a start request (true), as
+// opposed to finding the container already running and doing nothing (false)
+// - this lets callers distinguish a transition they caused from one that had
+// already happened, e.g. via a concurrent, unrelated operation.
+//
+// As with Stop(), this is a best-effort signal, not a guarantee: if another
+// actor starts the container in the narrow window between the Running() check
+// below and the ContainerStart() call, Docker's start endpoint is idempotent
+// and returns success either way, and the docker/docker/client SDK discards
+// the distinction the Docker Engine API makes there (204 "started by this
+// request" vs. 304 "already started"). That residual race is accepted.
+func (d *DockerService) Start() (bool, error) {
 	running, err := d.Running()
 	if err != nil {
-		return err
+		return false, err
 	}
-	if !running {
-		client, err := d.getClient()
-		if err != nil {
-			return err
-		}
-		d.logger.Debug("starting container " + d.ContainerName)
-		if err := client.ContainerStart(
-			context.Background(),
-			d.ContainerId,
-			container.StartOptions{},
-		); err != nil {
-			return err
-		}
+	if running {
+		return false, nil
 	}
-	return nil
+	client, err := d.getClient()
+	if err != nil {
+		return false, err
+	}
+	d.logger.Debug("starting container " + d.ContainerName)
+	if err := client.ContainerStart(
+		context.Background(),
+		d.ContainerId,
+		container.StartOptions{},
+	); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // Stop stops the container if it is running. The returned bool reports

--- a/pkgmgr/docker.go
+++ b/pkgmgr/docker.go
@@ -113,9 +113,14 @@ func (d *DockerService) Running() (bool, error) {
 // As with Stop(), this is a best-effort signal, not a guarantee: if another
 // actor starts the container in the narrow window between the Running() check
 // below and the ContainerStart() call, Docker's start endpoint is idempotent
-// and returns success either way, and the docker/docker/client SDK discards
-// the distinction the Docker Engine API makes there (204 "started by this
-// request" vs. 304 "already started"). That residual race is accepted.
+// and returns success either way. The Docker Engine API does distinguish the
+// two cases (204 "started by this request" vs. 304 "already started"), but
+// the underlying docker/docker/client SDK discards it - ContainerStart() only
+// returns an error, never the response status, and its shared error check
+// treats every status below 400 as success - so recovering the distinction
+// would require bypassing the SDK's exported API with a raw HTTP request.
+// Given that cost, this race is accepted rather than closed, exactly as on
+// the Stop() side.
 func (d *DockerService) Start() (bool, error) {
 	running, err := d.Running()
 	if err != nil {

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -73,7 +73,10 @@ type PackageOutput struct {
 
 type serviceLifecycle interface {
 	Running() (bool, error)
-	Start() error
+	// Start starts the service if it is not already running. The returned
+	// bool reports whether this call actually issued a start (true), versus
+	// finding it already running and doing nothing (false).
+	Start() (bool, error)
 	// Stop stops the service if it is running. The returned bool reports
 	// whether this call actually issued a stop (true), versus finding it
 	// already stopped and doing nothing (false).
@@ -688,26 +691,21 @@ func (p Package) startServices(
 				)
 				continue
 			}
-			wasRunning, err := dockerService.Running()
+			// Start() itself checks whether the container is already
+			// running before acting, and reports whether it actually issued
+			// a start. Relying on that report - rather than a separate
+			// Running() check made beforehand by this code - avoids a race
+			// where a concurrent, unrelated operation starts the container
+			// in between the two checks: this code would then see a
+			// "successful" no-op Start() and wrongly believe it owns a
+			// transition it never caused.
+			startedNow, err := dockerService.Start()
 			if err != nil {
-				startErrors = append(
-					startErrors,
-					fmt.Sprintf(
-						"error checking Docker container status for %s: %v",
-						containerName,
-						err,
-					),
-				)
-				continue
-			}
-			if wasRunning {
-				continue
-			}
-			// Start the Docker container if it's not running
-			slog.Info(
-				"Starting Docker container " + containerName,
-			)
-			if err := dockerService.Start(); err != nil {
+				// Don't track this service for rollback: the start may not
+				// have happened at all, and a container left running despite
+				// this error could have been started by a concurrent,
+				// unrelated operation, so stopping it would wrongly undo that
+				// operation's intended effect.
 				startErrors = append(
 					startErrors,
 					fmt.Sprintf(
@@ -718,6 +716,12 @@ func (p Package) startServices(
 				)
 				continue
 			}
+			if !startedNow {
+				// The container was already running; nothing to do or roll
+				// back, and no error since the desired end state holds.
+				continue
+			}
+			slog.Info("Started Docker container " + containerName)
 			startedServices = append(startedServices, dockerService)
 		}
 	}
@@ -890,7 +894,7 @@ func (p Package) rollbackStoppedServices(stoppedServices []serviceLifecycle) {
 		return
 	}
 	for idx := len(stoppedServices) - 1; idx >= 0; idx-- {
-		if err := stoppedServices[idx].Start(); err != nil {
+		if _, err := stoppedServices[idx].Start(); err != nil {
 			slog.Warn(
 				fmt.Sprintf(
 					"failed to roll back stopped service: %v",

--- a/pkgmgr/package_test.go
+++ b/pkgmgr/package_test.go
@@ -54,6 +54,12 @@ type fakeServiceLifecycle struct {
 	// after an attempt to stop the container.
 	runningErrAfterStop error
 
+	// startRaced, if true, simulates a concurrent, unrelated operation
+	// starting the container after this call's status check but before its
+	// Start(): Running() reports not-running, while Start() finds the
+	// container already running and does nothing.
+	startRaced bool
+
 	// onStart, if set, is called by Start() before the service is marked
 	// running. Lets a test observe when a container start happens relative
 	// to hook execution.
@@ -67,13 +73,20 @@ func (f *fakeServiceLifecycle) Running() (bool, error) {
 	return f.running, nil
 }
 
-func (f *fakeServiceLifecycle) Start() error {
+// Start mirrors DockerService.Start(): it only acts if the container is not
+// already running, matching the production contract that finding it already
+// running is a successful no-op rather than a transition this call caused.
+func (f *fakeServiceLifecycle) Start() (bool, error) {
 	if f.onStart != nil {
 		f.onStart()
 	}
+	if f.running || f.startRaced {
+		f.running = true
+		return false, nil
+	}
 	f.started = true
 	f.running = true
-	return nil
+	return true, nil
 }
 
 // Stop mirrors DockerService.Stop(): it only acts (and reports
@@ -774,5 +787,58 @@ func TestRunHookScriptError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "exited with error") {
 		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+// TestStartService_DoesNotRollBackAServiceItDidNotStart pins the ownership
+// contract on the start side: a container that a concurrent, unrelated
+// operation started between this call's status check and its Start() was not
+// started by this call, so a rollback must leave it running. Start() reports
+// whether it actually issued a start, and only a true report makes the
+// service this call's to roll back.
+func TestStartService_DoesNotRollBackAServiceItDidNotStart(t *testing.T) {
+	origNewServiceFromContainerName := newServiceFromContainerName
+	t.Cleanup(func() {
+		newServiceFromContainerName = origNewServiceFromContainerName
+	})
+
+	racedSvc := &fakeServiceLifecycle{startRaced: true}
+	newServiceFromContainerName = func(containerName string, logger *slog.Logger) (serviceLifecycle, error) {
+		return racedSvc, nil
+	}
+
+	cfg := Config{
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Template: NewTemplate(nil),
+	}
+	pkg := Package{
+		Name:            "mypkg",
+		Version:         "1.0.0",
+		PostStartScript: "exit 1",
+		InstallSteps: []PackageInstallStep{
+			{
+				Docker: &PackageInstallStepDocker{
+					ContainerName: "raced",
+					Image:         "alpine:3.20",
+				},
+			},
+		},
+	}
+
+	err := pkg.startService(cfg, "testctx")
+	if err == nil {
+		t.Fatal("expected post-start hook failure")
+	}
+	if !strings.Contains(err.Error(), "post-start hook failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if racedSvc.started {
+		t.Fatal("expected the raced container to not be started by this call")
+	}
+	if racedSvc.stopped {
+		t.Fatal(
+			"rollback stopped the raced container: startService claimed " +
+				"a transition the concurrent actor caused, not this call",
+		)
 	}
 }


### PR DESCRIPTION
Closes blinklabs-io/cardano-up#580

`serviceLifecycle.Start()` returned only `error`, so `startServices` could not
tell a start it issued from a container it found already running. It
compensated with a separate `Running()` check, which loses the race where a
concurrent, unrelated operation starts the container between the check and the
act: `DockerService.Start()` then finds it running, skips `ContainerStart`, and
returns nil — and the service is tracked in `startedServices`. A later rollback
stops a container this call never started.

## Change

- `Start()` gets the shape `Stop()` already has: `(bool, error)`, false when the
  container was found already running.
- `startServices` drops the now-redundant `Running()` pre-check and consumes
  `Start()`'s report, mirroring how `stopService` consumes `Stop()`. Only a true
  report appends to `startedServices`. This also removes a redundant Docker
  inspect round-trip, since `Start()` performs that check itself.
- `fakeServiceLifecycle.Start()` now mirrors the production contract (no-op when
  already running), as its `Stop()` already did.

`DockerService.Start()` is exported, so its signature change is breaking for
external importers of `pkgmgr` — the same shape change `Stop()` took in #575.

## Tests

`TestStartService_DoesNotRollBackAServiceItDidNotStart` fails without the fix:

```
--- FAIL: TestStartService_DoesNotRollBackAServiceItDidNotStart
    rollback stopped the raced container: startService claimed a transition
    the concurrent actor caused, not this call
```

## Validation

- `go build ./...`
- `go test -race ./...`
- `golangci-lint run ./...` — 0 issues
- `nilaway -include-pkgs=github.com/blinklabs-io/cardano-up ./...` — clean
- `gofmt -l .` — clean

Not run: Docker-backed integration paths (no live daemon exercised); coverage is
via the `serviceLifecycle` fake.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents rollback from stopping containers we didn’t start by having `Start()` report whether it actually issued a start. Previously `Start()` returned only `error`, so a race with a concurrent start could cause us to track and later stop an unrelated container; now `Start()` returns `(bool, error)` and `startServices` tracks only services it started.

- `DockerService.Start()` now returns `(bool, error)`. `startServices` drops the pre-`Running()` check, relies on `Start()`’s report, and logs only when it actually starts. The fake implementation mirrors this contract and remains a no-op when already running. Tests pin the rollback behavior.

**Breaking change and rollout**
- Update callers: handle the `(bool, error)` from `DockerService.Start()`; treat `false` as “already running” and do not record ownership.
- If you implement `serviceLifecycle`, change `Start()` to `(bool, error)` with the same semantics.
- Remove pre-`Running()` checks in callers; rely on `Start()` to avoid start/rollback races.

**Notes**
- Docs explain why the 204/304 “already started” distinction is not closed: the `docker/docker` client’s `ContainerStart` does not expose response status and treats all <400 as success, so `Start()` provides a best-effort signal (matching `Stop()`).

<sup>Written for commit a137aab21110c8e633f4287a3da0e377adcd3c40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up/pull/583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service startup handling when multiple operations attempt to start the same container.
  * Prevented rollback from stopping a service that was already running or started by another operation.
  * More accurately tracks services started during the current package startup process.
  * Reduced race-related failures during startup and cleanup when concurrent operations are in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->