### PR TITLE
feat(pkgmgr): add config install step primitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,36 @@ installSteps:
 | `archive` | | Archive format that `source` or `url` content should be extracted from. One of `zip`, `tar.gz`, or `tgz` |
 | `archivePath` | | Path of the file within the archive to extract as the destination file content. Required if `archive` is set. Supports templating |
 
+###### `config`
+
+The `config` install step type manages a configuration file. It supports the same content sources as `file`, but differs in two ways that make it suitable
+for files a user may want to hand-edit:
+
+* The destination file is created within the context directory (shared and persisted across the package's own versions), rather than the package's
+  per-version data directory used by `file`.
+* Once the destination file exists, later installs leave it untouched instead of overwriting it. This means a package upgrade will not clobber a
+  configuration file the user has customized since it was first installed. A `config` file is likewise left in place on uninstall; remove it manually if
+  you no longer want it.
+
+Example:
+
+```yaml
+installSteps:
+  - config:
+      filename: my-app/settings.yaml
+      source: my-source-settings.yaml
+```
+
+| Field | Required | Description |
+| --- | :---: | --- |
+| `filename` | x | Path of destination file, relative to the context directory |
+| `source` | | Path to source file. This should be a relative path within the package manifest directory. Used only if `content` is not provided |
+| `content` | | Inline content for destination file. Takes precedence over `source` and `url` if more than one is provided |
+| `url` | | URL to fetch destination file content from. Used only if `content` and `source` are not provided. Supports templating (e.g. `{{ .System.OS }}` and `{{ .System.ARCH }}`) |
+| `mode` | | Octal file mode for destination file |
+| `archive` | | Archive format that `source` or `url` content should be extracted from. One of `zip`, `tar.gz`, or `tgz` |
+| `archivePath` | | Path of the file within the archive to extract as the destination file content. Required if `archive` is set. Supports templating |
+
 ##### `dependencies`
 
 Dependencies for a package are specified in the following format. At minimum they contain a package name. They may optionally contain a list of required package

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -1414,6 +1414,10 @@ func (p *PackageInstallStepConfig) asFile() *PackageInstallStepFile {
 }
 
 func (p *PackageInstallStepConfig) validate(cfg Config) error {
+	if p.Filename == "" {
+		cfg.Logger.Debug("config file missing filename")
+		return errors.New("filename must be provided for config install types")
+	}
 	return p.asFile().validate(cfg)
 }
 
@@ -1427,25 +1431,36 @@ func (p *PackageInstallStepConfig) install(
 		return err
 	}
 	pkgContextDir := filepath.Join(cfg.DataDir, context)
-	filePath := filepath.Join(pkgContextDir, tmpFilePath)
-	filePath = filepath.Clean(filePath)
-	expectedPrefix := filepath.Clean(pkgContextDir) + string(os.PathSeparator)
-	if !strings.HasPrefix(filePath, expectedPrefix) {
-		return fmt.Errorf("invalid file path %q: path traversal detected", filePath)
+	if err := os.MkdirAll(pkgContextDir, fs.ModePerm); err != nil {
+		return err
 	}
+	relFilePath := filepath.Clean(tmpFilePath)
+	displayPath := filepath.Join(pkgContextDir, relFilePath)
+	// Open the context directory as an os.Root and do every subsequent
+	// filesystem operation through it. Unlike a lexical prefix check on the
+	// resolved path, Root rejects any component - including a symlink placed
+	// inside the context directory by a prior install step - that would
+	// resolve outside pkgContextDir, so a malicious or buggy filename can't
+	// escape it even via an intermediate symlink.
+	root, err := os.OpenRoot(pkgContextDir)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
 	// Preserve an existing config file rather than overwriting it. This is
 	// what lets a package upgrade run install() again - via Upgrade(), which
 	// uninstalls the old version and installs the new one - without losing
 	// any changes the user made to the file after the initial install.
-	if _, err := os.Stat(filePath); err == nil {
-		cfg.Logger.Debug("preserving existing config file " + filePath)
+	if _, err := root.Lstat(relFilePath); err == nil {
+		cfg.Logger.Debug("preserving existing config file " + displayPath)
 		return nil
 	} else if !errors.Is(err, fs.ErrNotExist) {
-		return err
+		return fmt.Errorf("invalid file path %q: %w", displayPath, err)
 	}
-	parentDir := filepath.Dir(filePath)
-	if err := os.MkdirAll(parentDir, fs.ModePerm); err != nil {
-		return err
+	if parentDir := filepath.Dir(relFilePath); parentDir != "." {
+		if err := root.MkdirAll(parentDir, fs.ModePerm); err != nil {
+			return fmt.Errorf("invalid file path %q: %w", displayPath, err)
+		}
 	}
 	fileMode := fs.ModePerm
 	if p.Mode > 0 {
@@ -1455,10 +1470,19 @@ func (p *PackageInstallStepConfig) install(
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(filePath, fileContent, fileMode); err != nil { //nolint:gosec // path traversal mitigated by prefix check above
+	f, err := root.OpenFile(
+		relFilePath,
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
+		fileMode,
+	)
+	if err != nil {
+		return fmt.Errorf("invalid file path %q: %w", displayPath, err)
+	}
+	defer f.Close()
+	if _, err := f.Write(fileContent); err != nil {
 		return err
 	}
-	cfg.Logger.Debug("wrote config file " + filePath)
+	cfg.Logger.Debug("wrote config file " + displayPath)
 	return nil
 }
 

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -169,8 +169,7 @@ func (p Package) install(
 	// Run pre-flight checks
 	for _, installStep := range p.InstallSteps {
 		// Make sure only one install method is specified per install step
-		if installStep.Docker != nil &&
-			installStep.File != nil {
+		if installStep.countInstallMethods() > 1 {
 			return "", nil, nil, ErrMultipleInstallMethods
 		}
 		if installStep.Docker != nil {
@@ -221,6 +220,10 @@ func (p Package) install(
 			}
 		} else if installStep.File != nil {
 			if err := installStep.File.install(cfg, pkgName, p.filePath); err != nil {
+				return "", nil, nil, err
+			}
+		} else if installStep.Config != nil {
+			if err := installStep.Config.install(cfg, context, p.filePath); err != nil {
 				return "", nil, nil, err
 			}
 		} else {
@@ -394,8 +397,7 @@ func (p Package) uninstall(
 			}
 		}
 		// Make sure only one install method is specified per install step
-		if installStep.Docker != nil &&
-			installStep.File != nil {
+		if installStep.countInstallMethods() > 1 {
 			return ErrMultipleInstallMethods
 		}
 		if installStep.Docker != nil {
@@ -404,6 +406,10 @@ func (p Package) uninstall(
 			}
 		} else if installStep.File != nil {
 			if err := installStep.File.uninstall(cfg, pkgName); err != nil {
+				return err
+			}
+		} else if installStep.Config != nil {
+			if err := installStep.Config.uninstall(cfg, context); err != nil {
 				return err
 			}
 		} else {
@@ -489,6 +495,10 @@ func (p Package) activate(cfg Config, context string) error {
 			if err := installStep.File.activate(cfg, pkgName); err != nil {
 				return err
 			}
+		} else if installStep.Config != nil {
+			if err := installStep.Config.activate(cfg, pkgName); err != nil {
+				return err
+			}
 		} else {
 			return ErrNoInstallMethods
 		}
@@ -516,6 +526,10 @@ func (p Package) deactivate(cfg Config, context string) error {
 			}
 		} else if installStep.File != nil {
 			if err := installStep.File.deactivate(cfg, pkgName); err != nil {
+				return err
+			}
+		} else if installStep.Config != nil {
+			if err := installStep.Config.deactivate(cfg, pkgName); err != nil {
 				return err
 			}
 		} else {
@@ -566,12 +580,20 @@ func (p Package) validate(cfg Config) error {
 				return NewInstallStepConditionError(installStep.Condition, err)
 			}
 		}
+		// Make sure only one install method is specified per install step
+		if installStep.countInstallMethods() > 1 {
+			return ErrMultipleInstallMethods
+		}
 		if installStep.Docker != nil {
 			if err := installStep.Docker.validate(cfg); err != nil {
 				return err
 			}
 		} else if installStep.File != nil {
 			if err := installStep.File.validate(cfg); err != nil {
+				return err
+			}
+		} else if installStep.Config != nil {
+			if err := installStep.Config.validate(cfg); err != nil {
 				return err
 			}
 		} else {
@@ -882,6 +904,23 @@ type PackageInstallStep struct {
 	Condition string                    `yaml:"condition,omitempty"`
 	Docker    *PackageInstallStepDocker `yaml:"docker,omitempty"`
 	File      *PackageInstallStepFile   `yaml:"file,omitempty"`
+	Config    *PackageInstallStepConfig `yaml:"config,omitempty"`
+}
+
+// countInstallMethods returns how many install method fields (docker, file,
+// config) are set on this install step. Exactly one is required per step.
+func (installStep PackageInstallStep) countInstallMethods() int {
+	count := 0
+	if installStep.Docker != nil {
+		count++
+	}
+	if installStep.File != nil {
+		count++
+	}
+	if installStep.Config != nil {
+		count++
+	}
+	return count
 }
 
 type PackageInstallStepDocker struct {
@@ -1149,11 +1188,30 @@ func (p *PackageInstallStepFile) install(
 	if p.Mode > 0 {
 		fileMode = p.Mode
 	}
+	fileContent, err := p.resolveContent(cfg, packagePath)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filePath, fileContent, fileMode); err != nil { //nolint:gosec // path traversal mitigated by prefix check above
+		return err
+	}
+	cfg.Logger.Debug("wrote file " + filePath)
+	return nil
+}
+
+// resolveContent renders this file's content from whichever of content,
+// source, or url is set, extracting an archive member first when Archive is
+// set. It holds the logic shared by the file and config install step types,
+// which differ only in their destination path and overwrite behavior.
+func (p *PackageInstallStepFile) resolveContent(
+	cfg Config,
+	packagePath string,
+) ([]byte, error) {
 	var fileContent []byte
 	if p.Content != "" {
 		tmpContent, err := cfg.Template.Render(p.Content, nil)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		fileContent = []byte(tmpContent)
 	} else if p.Source != "" {
@@ -1168,78 +1226,74 @@ func (p *PackageInstallStepFile) install(
 			// into memory before the archive-entry limit even runs.
 			sourceFile, err := os.Open(fullSourcePath)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			defer sourceFile.Close()
 			tmpContentBytes, err := readArchiveEntry(sourceFile, fullSourcePath, maxDownloadSize)
 			if err != nil {
-				return fmt.Errorf("failed to read %q: %w", fullSourcePath, err)
+				return nil, fmt.Errorf("failed to read %q: %w", fullSourcePath, err)
 			}
 			fileContent = tmpContentBytes
 		} else {
 			tmpContentBytes, err := os.ReadFile(fullSourcePath)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			tmpContent, err := cfg.Template.Render(string(tmpContentBytes), nil)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			fileContent = []byte(tmpContent)
 		}
 	} else if p.Url != "" {
 		tmpUrl, err := cfg.Template.Render(p.Url, nil)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		// Validate URL
 		u, err := url.Parse(tmpUrl)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if u.Scheme == "" || u.Host == "" {
-			return errors.New("invalid URL given")
+			return nil, errors.New("invalid URL given")
 		}
 
 		// Fetch data
 		ctx := context.Background()
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, tmpUrl, nil)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		resp, err := http.DefaultClient.Do(req) //nolint:gosec // URL is validated above
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if resp == nil {
-			return fmt.Errorf("nil response for URL: %s", tmpUrl)
+			return nil, fmt.Errorf("nil response for URL: %s", tmpUrl)
 		}
 		defer resp.Body.Close()
 		respBody, err := readArchiveEntry(resp.Body, tmpUrl, maxDownloadSize)
 		if err != nil {
-			return fmt.Errorf("failed to download %q: %w", tmpUrl, err)
+			return nil, fmt.Errorf("failed to download %q: %w", tmpUrl, err)
 		}
 
 		fileContent = respBody
 	} else {
-		return errors.New("packages must provide content, source, or url for file install types")
+		return nil, errors.New("packages must provide content, source, or url for file install types")
 	}
 	if p.Archive != "" {
 		tmpArchivePath, err := cfg.Template.Render(p.ArchivePath, nil)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		fileContent, err = extractArchiveFile(p.Archive, tmpArchivePath, fileContent)
 		if err != nil {
-			return fmt.Errorf("failed to extract %q from archive: %w", tmpArchivePath, err)
+			return nil, fmt.Errorf("failed to extract %q from archive: %w", tmpArchivePath, err)
 		}
 	}
-	if err := os.WriteFile(filePath, fileContent, fileMode); err != nil { //nolint:gosec // path traversal mitigated by prefix check above
-		return err
-	}
-	cfg.Logger.Debug("wrote file " + filePath)
-	return nil
+	return fileContent, nil
 }
 
 func (p *PackageInstallStepFile) uninstall(cfg Config, pkgName string) error {
@@ -1327,6 +1381,104 @@ func (p *PackageInstallStepFile) deactivate(cfg Config, pkgName string) error {
 		}
 		cfg.Logger.Debug("removed symlink " + binPath + "for " + pkgName)
 	}
+	return nil
+}
+
+// PackageInstallStepConfig manages a configuration file. Unlike the file
+// install step, a config file lives in the context-level directory (shared
+// and persisted across the package's own versions, rather than the
+// per-version package data directory) and, once written, is never
+// overwritten by a later install. This lets a package upgrade change its
+// rendered defaults without clobbering a config file the user has hand-edited
+// since the initial install. See issue #567.
+type PackageInstallStepConfig struct {
+	Filename    string      `yaml:"filename"`
+	Source      string      `yaml:"source,omitempty"`
+	Content     string      `yaml:"content,omitempty"`
+	Url         string      `yaml:"url,omitempty"`
+	Mode        fs.FileMode `yaml:"mode,omitempty"`
+	Archive     string      `yaml:"archive,omitempty"`
+	ArchivePath string      `yaml:"archivePath,omitempty"`
+}
+
+// asFile adapts this config step to a PackageInstallStepFile so it can reuse
+// the file step's content-source validation and resolution.
+func (p *PackageInstallStepConfig) asFile() *PackageInstallStepFile {
+	return &PackageInstallStepFile{
+		Content:     p.Content,
+		Source:      p.Source,
+		Url:         p.Url,
+		Archive:     p.Archive,
+		ArchivePath: p.ArchivePath,
+	}
+}
+
+func (p *PackageInstallStepConfig) validate(cfg Config) error {
+	return p.asFile().validate(cfg)
+}
+
+func (p *PackageInstallStepConfig) install(
+	cfg Config,
+	context string,
+	packagePath string,
+) error {
+	tmpFilePath, err := cfg.Template.Render(p.Filename, nil)
+	if err != nil {
+		return err
+	}
+	pkgContextDir := filepath.Join(cfg.DataDir, context)
+	filePath := filepath.Join(pkgContextDir, tmpFilePath)
+	filePath = filepath.Clean(filePath)
+	expectedPrefix := filepath.Clean(pkgContextDir) + string(os.PathSeparator)
+	if !strings.HasPrefix(filePath, expectedPrefix) {
+		return fmt.Errorf("invalid file path %q: path traversal detected", filePath)
+	}
+	// Preserve an existing config file rather than overwriting it. This is
+	// what lets a package upgrade run install() again - via Upgrade(), which
+	// uninstalls the old version and installs the new one - without losing
+	// any changes the user made to the file after the initial install.
+	if _, err := os.Stat(filePath); err == nil {
+		cfg.Logger.Debug("preserving existing config file " + filePath)
+		return nil
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	parentDir := filepath.Dir(filePath)
+	if err := os.MkdirAll(parentDir, fs.ModePerm); err != nil {
+		return err
+	}
+	fileMode := fs.ModePerm
+	if p.Mode > 0 {
+		fileMode = p.Mode
+	}
+	fileContent, err := p.asFile().resolveContent(cfg, packagePath)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filePath, fileContent, fileMode); err != nil { //nolint:gosec // path traversal mitigated by prefix check above
+		return err
+	}
+	cfg.Logger.Debug("wrote config file " + filePath)
+	return nil
+}
+
+// uninstall intentionally leaves the config file in place. It is never
+// recreated by install() once it exists, so deleting it here - whether for a
+// real uninstall or as the first half of an Upgrade() - would either destroy
+// user changes or force every upgrade to fall back to the package's rendered
+// defaults, defeating the point of this install step type. A user who wants
+// the file gone can remove it manually.
+func (p *PackageInstallStepConfig) uninstall(cfg Config, context string) error {
+	return nil
+}
+
+func (p *PackageInstallStepConfig) activate(cfg Config, pkgName string) error {
+	// Nothing to do
+	return nil
+}
+
+func (p *PackageInstallStepConfig) deactivate(cfg Config, pkgName string) error {
+	// Nothing to do
 	return nil
 }
 

--- a/pkgmgr/package_config_test.go
+++ b/pkgmgr/package_config_test.go
@@ -1,0 +1,285 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkgmgr
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestPackageInstallStepConfigValidate checks that the config install step
+// enforces the same content-source rules as the file install step.
+func TestPackageInstallStepConfigValidate(t *testing.T) {
+	testDefs := []struct {
+		step      PackageInstallStepConfig
+		expectErr bool
+	}{
+		{
+			step:      PackageInstallStepConfig{Content: "foo"},
+			expectErr: false,
+		},
+		{
+			step:      PackageInstallStepConfig{},
+			expectErr: true,
+		},
+		{
+			step: PackageInstallStepConfig{
+				Url:     "https://example.com/foo.zip",
+				Archive: "zip",
+			},
+			expectErr: true, // missing archivePath
+		},
+		{
+			step: PackageInstallStepConfig{
+				Content:     "foo",
+				Archive:     "zip",
+				ArchivePath: "bin/foo",
+			},
+			expectErr: true, // archive cannot be combined with content
+		},
+	}
+	cfg := newArchiveTestConfig(t)
+	for _, testDef := range testDefs {
+		err := testDef.step.validate(cfg)
+		if testDef.expectErr && err == nil {
+			t.Errorf("expected error for step %#v, got nil", testDef.step)
+		}
+		if !testDef.expectErr && err != nil {
+			t.Errorf("unexpected error for step %#v: %s", testDef.step, err)
+		}
+	}
+}
+
+// TestPackageInstallStepConfigInstallWritesOnFirstInstall checks that a
+// config file is written under the context directory (not the per-version
+// package data directory) the first time it is installed.
+func TestPackageInstallStepConfigInstallWritesOnFirstInstall(t *testing.T) {
+	cfg := newArchiveTestConfig(t)
+	step := &PackageInstallStepConfig{
+		Filename: "myapp/settings.yaml",
+		Content:  "default: true\n",
+	}
+	if err := step.install(cfg, "testctx", ""); err != nil {
+		t.Fatalf("install failed: %s", err)
+	}
+	writtenPath := filepath.Join(cfg.DataDir, "testctx", "myapp/settings.yaml")
+	content, err := os.ReadFile(writtenPath)
+	if err != nil {
+		t.Fatalf("unexpected error reading installed file: %s", err)
+	}
+	if string(content) != "default: true\n" {
+		t.Fatalf(
+			"did not get expected content\n  got: %q\n  expected: %q",
+			content,
+			"default: true\n",
+		)
+	}
+}
+
+// TestPackageInstallStepConfigInstallPreservesExistingFile checks that a
+// second install (as happens on package upgrade) does not overwrite a config
+// file that already exists, even though its rendered content differs. This
+// is the behavior requested in issue #567: a config file survives a package
+// upgrade with any user edits intact.
+func TestPackageInstallStepConfigInstallPreservesExistingFile(t *testing.T) {
+	cfg := newArchiveTestConfig(t)
+	step := &PackageInstallStepConfig{
+		Filename: "settings.yaml",
+		Content:  "default: true\n",
+	}
+	if err := step.install(cfg, "testctx", ""); err != nil {
+		t.Fatalf("first install failed: %s", err)
+	}
+	writtenPath := filepath.Join(cfg.DataDir, "testctx", "settings.yaml")
+	userContent := "default: true\ncustom: user edit\n"
+	if err := os.WriteFile(writtenPath, []byte(userContent), 0o644); err != nil {
+		t.Fatalf("failed to simulate user edit: %s", err)
+	}
+
+	upgradeStep := &PackageInstallStepConfig{
+		Filename: "settings.yaml",
+		Content:  "default: true\nnewOption: added-in-upgrade\n",
+	}
+	if err := upgradeStep.install(cfg, "testctx", ""); err != nil {
+		t.Fatalf("second install failed: %s", err)
+	}
+
+	content, err := os.ReadFile(writtenPath)
+	if err != nil {
+		t.Fatalf("unexpected error reading installed file: %s", err)
+	}
+	if string(content) != userContent {
+		t.Fatalf(
+			"install overwrote existing config file\n  got: %q\n  expected: %q",
+			content,
+			userContent,
+		)
+	}
+}
+
+// TestPackageInstallStepConfigInstallPathTraversal checks that a filename
+// escaping the context directory is rejected, mirroring the file install
+// step's path traversal check.
+func TestPackageInstallStepConfigInstallPathTraversal(t *testing.T) {
+	cfg := newArchiveTestConfig(t)
+	step := &PackageInstallStepConfig{
+		Filename: "../escape.yaml",
+		Content:  "foo",
+	}
+	if err := step.install(cfg, "testctx", ""); err == nil {
+		t.Fatal("expected error for path traversal, got nil")
+	}
+	if _, err := os.Stat(filepath.Join(cfg.DataDir, "escape.yaml")); err == nil {
+		t.Fatal("expected no file to be written outside the context directory")
+	}
+}
+
+// TestPackageInstallStepConfigInstallFromArchive checks that config content
+// can be extracted from a source archive, reusing the same resolution logic
+// as the file install step.
+func TestPackageInstallStepConfigInstallFromArchive(t *testing.T) {
+	cfg := newArchiveTestConfig(t)
+	pkgSourceDir := t.TempDir()
+	zipPath := filepath.Join(pkgSourceDir, "release.zip")
+	zipData := buildTestZip(t, map[string]string{
+		"config/settings.yaml": testArchiveFileContent,
+	})
+	if err := os.WriteFile(zipPath, zipData, 0o644); err != nil {
+		t.Fatalf("unexpected error writing test zip: %s", err)
+	}
+
+	step := &PackageInstallStepConfig{
+		Filename:    "settings.yaml",
+		Source:      "release.zip",
+		Archive:     "zip",
+		ArchivePath: "config/settings.yaml",
+	}
+	packagePath := filepath.Join(pkgSourceDir, "test-1.0.0.yaml")
+	if err := step.install(cfg, "testctx", packagePath); err != nil {
+		t.Fatalf("install failed: %s", err)
+	}
+
+	writtenPath := filepath.Join(cfg.DataDir, "testctx", "settings.yaml")
+	content, err := os.ReadFile(writtenPath)
+	if err != nil {
+		t.Fatalf("unexpected error reading installed file: %s", err)
+	}
+	if string(content) != testArchiveFileContent {
+		t.Fatalf(
+			"did not get expected content\n  got: %q\n  expected: %q",
+			content,
+			testArchiveFileContent,
+		)
+	}
+}
+
+// TestPackageInstallStepConfigUninstallPreservesFile checks that uninstall
+// leaves the config file in place instead of deleting it.
+func TestPackageInstallStepConfigUninstallPreservesFile(t *testing.T) {
+	cfg := newArchiveTestConfig(t)
+	step := &PackageInstallStepConfig{
+		Filename: "settings.yaml",
+		Content:  "default: true\n",
+	}
+	if err := step.install(cfg, "testctx", ""); err != nil {
+		t.Fatalf("install failed: %s", err)
+	}
+	if err := step.uninstall(cfg, "testctx"); err != nil {
+		t.Fatalf("uninstall failed: %s", err)
+	}
+	writtenPath := filepath.Join(cfg.DataDir, "testctx", "settings.yaml")
+	if _, err := os.Stat(writtenPath); err != nil {
+		t.Fatalf("expected config file to survive uninstall: %s", err)
+	}
+}
+
+// TestPackageUpgradePreservesConfigFileAcrossVersions exercises the same
+// deactivate/uninstall(keepData=true)/install sequence PackageManager.Upgrade
+// runs, across two package versions sharing a context, and checks that a
+// user edit made to the config file after the first install survives the
+// upgrade to the second version untouched.
+func TestPackageUpgradePreservesConfigFileAcrossVersions(t *testing.T) {
+	cfg := newArchiveTestConfig(t)
+	const context = "testctx"
+
+	newPkg := func(version, content string) Package {
+		return Package{
+			Name:    "myapp",
+			Version: version,
+			InstallSteps: []PackageInstallStep{
+				{
+					Config: &PackageInstallStepConfig{
+						Filename: "config/settings.yaml",
+						Content:  content,
+					},
+				},
+			},
+		}
+	}
+	v1 := newPkg("1.0.0", "version: 1.0.0 default\n")
+	v2 := newPkg("2.0.0", "version: 2.0.0 default\n")
+
+	if _, _, _, err := v1.install(cfg, context, nil, false, nil); err != nil {
+		t.Fatalf("v1 install failed: %s", err)
+	}
+
+	configPath := filepath.Join(cfg.DataDir, context, "config", "settings.yaml")
+	userContent := "version: 1.0.0 default\ncustom: user edit\n"
+	if err := os.WriteFile(configPath, []byte(userContent), 0o644); err != nil {
+		t.Fatalf("failed to simulate user edit: %s", err)
+	}
+
+	// Mirrors PackageManager.Upgrade: uninstall the old version with
+	// keepData=true, then install the new version into the same context.
+	if err := v1.uninstall(cfg, context, true, false); err != nil {
+		t.Fatalf("v1 uninstall failed: %s", err)
+	}
+	if _, _, _, err := v2.install(cfg, context, nil, false, nil); err != nil {
+		t.Fatalf("v2 install failed: %s", err)
+	}
+
+	got, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read config file after upgrade: %s", err)
+	}
+	if string(got) != userContent {
+		t.Fatalf(
+			"upgrade clobbered user config\n  got: %q\n  expected: %q",
+			got,
+			userContent,
+		)
+	}
+}
+
+// TestPackageInstallStepMultipleMethodsRejected checks that specifying more
+// than one install method (docker, file, config) on a single step is
+// rejected, now that there are three mutually exclusive method fields.
+func TestPackageInstallStepMultipleMethodsRejected(t *testing.T) {
+	cfg := newArchiveTestConfig(t)
+	pkg := Package{
+		Name:    "myapp",
+		Version: "1.0.0",
+		InstallSteps: []PackageInstallStep{
+			{
+				File:   &PackageInstallStepFile{Content: "foo"},
+				Config: &PackageInstallStepConfig{Content: "foo"},
+			},
+		},
+	}
+	if _, _, _, err := pkg.install(cfg, "testctx", nil, false, nil); err == nil {
+		t.Fatal("expected error for multiple install methods, got nil")
+	}
+}

--- a/pkgmgr/package_config_test.go
+++ b/pkgmgr/package_config_test.go
@@ -28,7 +28,7 @@ func TestPackageInstallStepConfigValidate(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			step:      PackageInstallStepConfig{Content: "foo"},
+			step:      PackageInstallStepConfig{Filename: "settings.yaml", Content: "foo"},
 			expectErr: false,
 		},
 		{
@@ -36,14 +36,20 @@ func TestPackageInstallStepConfigValidate(t *testing.T) {
 			expectErr: true,
 		},
 		{
+			step:      PackageInstallStepConfig{Content: "foo"},
+			expectErr: true, // missing filename
+		},
+		{
 			step: PackageInstallStepConfig{
-				Url:     "https://example.com/foo.zip",
-				Archive: "zip",
+				Filename: "settings.yaml",
+				Url:      "https://example.com/foo.zip",
+				Archive:  "zip",
 			},
 			expectErr: true, // missing archivePath
 		},
 		{
 			step: PackageInstallStepConfig{
+				Filename:    "settings.yaml",
 				Content:     "foo",
 				Archive:     "zip",
 				ArchivePath: "bin/foo",
@@ -144,6 +150,32 @@ func TestPackageInstallStepConfigInstallPathTraversal(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(cfg.DataDir, "escape.yaml")); err == nil {
 		t.Fatal("expected no file to be written outside the context directory")
+	}
+}
+
+// TestPackageInstallStepConfigInstallSymlinkedParentRejected checks that a
+// symlink placed inside the context directory cannot be used to redirect a
+// write outside of it, even though the filename itself contains no "..".
+func TestPackageInstallStepConfigInstallSymlinkedParentRejected(t *testing.T) {
+	cfg := newArchiveTestConfig(t)
+	contextDir := filepath.Join(cfg.DataDir, "testctx")
+	if err := os.MkdirAll(contextDir, 0o755); err != nil {
+		t.Fatalf("unexpected error creating context directory: %s", err)
+	}
+	outsideDir := t.TempDir()
+	if err := os.Symlink(outsideDir, filepath.Join(contextDir, "link")); err != nil {
+		t.Fatalf("unexpected error creating symlink: %s", err)
+	}
+
+	step := &PackageInstallStepConfig{
+		Filename: "link/settings.yaml",
+		Content:  "foo",
+	}
+	if err := step.install(cfg, "testctx", ""); err == nil {
+		t.Fatal("expected error for symlink escape, got nil")
+	}
+	if _, err := os.Stat(filepath.Join(outsideDir, "settings.yaml")); err == nil {
+		t.Fatal("expected no file to be written outside the context directory via the symlink")
 	}
 }
 


### PR DESCRIPTION
## Problem

Config files installed via the `file` install step live in the
package's per-version data directory and are unconditionally deleted
and rewritten on every upgrade, so any hand-edited configuration is
lost when the package version changes.

Closes #567

## Changes

- Add a `config` install step type. It writes to the context
  directory (shared across the package's own versions, unlike `file`'s
  per-version data directory) and, once the destination file exists,
  a later install leaves it in place instead of overwriting it -
  package upgrades no longer clobber a user's edits. Uninstall
  likewise leaves the file in place.
- Extract `file`'s content-resolution logic (content/source/url,
  archive extraction) into a shared helper reused by `config`.
- Extend the install-method multiplicity check (previously only
  checked in two of the five step-dispatch loops, and only for
  docker+file) to all three step types and to `validate()` as well.
- Document the `config` step in the README.

## Checks

- `make mod-tidy` / `make format`: no changes beyond this PR's diff
- `make test` (`go test -v -race ./...`): pass
- `golangci-lint run ./...`: no findings in changed files (2
  pre-existing `gofumpt` findings in unrelated files, not touched by
  this change)
- `nilaway ./...`: clean
- New tests prove the fix: reverting the preserve-on-exists check
  makes `TestPackageInstallStepConfigInstallPreservesExistingFile` and
  `TestPackageUpgradePreservesConfigFileAcrossVersions` fail; both
  pass with the fix in place

## Not validated

- Docker CI / multi-arch build (requires CI infrastructure)
- No `cardano-up-packages` manifest was changed to use the new step;
  that's a separate repository and out of scope here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuration-file installation steps.
  * Configuration files can be sourced from content, URLs, or archives.
  * Existing configuration files are preserved during installation, upgrades, and removal.
  * Added protection against unsafe file paths.
* **Documentation**
  * Documented configuration-file installation, supported fields, and YAML examples.
* **Bug Fixes**
  * Install steps now consistently reject multiple methods being configured at once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->