### PR TITLE
fix(pkgmgr): address PR #561 review follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ installSteps:
 | `binary` | | Whether this file is an executable file for the package (expects bool, defaults to `false`) |
 | `archive` | | Archive format that `source` or `url` content should be extracted from. One of `zip`, `tar.gz`, or `tgz` |
 | `archivePath` | | Path of the file within the archive to extract as the destination file content. Required if `archive` is set. Supports templating |
-| `archiveMaxSize` | | Maximum decompressed size in bytes for the selected archive entry, overriding the default of 512 MiB. Only valid if `archive` is set. Capped at 4 GiB |
+| `archiveMaxSize` | | Maximum decompressed size in bytes. For `zip`, this limits the selected entry. For `tar.gz` and `tgz`, this limits total decompressed archive data. Overrides the default of 512 MiB. Only valid if `archive` is set. Capped at 4 GiB |
 
 ###### `config`
 

--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ installSteps:
 | `binary` | | Whether this file is an executable file for the package (expects bool, defaults to `false`) |
 | `archive` | | Archive format that `source` or `url` content should be extracted from. One of `zip`, `tar.gz`, or `tgz` |
 | `archivePath` | | Path of the file within the archive to extract as the destination file content. Required if `archive` is set. Supports templating |
+| `archiveMaxSize` | | Maximum decompressed size in bytes for the selected archive entry, overriding the default of 512 MiB. Only valid if `archive` is set. Capped at 4 GiB |
 
 ###### `config`
 

--- a/pkgmgr/archive.go
+++ b/pkgmgr/archive.go
@@ -24,21 +24,44 @@ import (
 	"io"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // Supported values for the file install step's archive field
 const (
-	archiveTypeZip      = "zip"
-	archiveTypeTarGz    = "tar.gz"
-	archiveTypeTgz      = "tgz"
-	maxArchiveEntrySize = int64(512 * 1024 * 1024) // 512 MiB
+	archiveTypeZip   = "zip"
+	archiveTypeTarGz = "tar.gz"
+	archiveTypeTgz   = "tgz"
 )
 
-// maxDownloadSize bounds how much of a url-sourced file install step is
-// buffered into memory, so an oversized or malicious response can't exhaust
-// process memory before archive extraction limits even apply. It's a var
-// rather than a const so tests can lower it without downloading 512MiB+.
+// maxArchiveEntrySize bounds the decompressed size of any single file read
+// from an archive or the local filesystem. A file install step can raise
+// this for its own archive via archiveMaxSize, up to maxArchiveSizeCeiling.
+// It's a var rather than a const so tests can lower it without needing
+// multi-GiB test data.
+var maxArchiveEntrySize = int64(512 * 1024 * 1024) // 512 MiB
+
+// maxArchiveSizeCeiling bounds how high a package's archiveMaxSize override
+// can raise maxArchiveEntrySize. tar.gz extraction has to bound decompressed
+// bytes as it streams through the archive looking for the requested entry
+// (there's no central directory to consult up front, unlike ZIP), so this
+// ceiling keeps a careless or malicious override from turning that bound
+// into an effectively unbounded decompression sink. It's a var rather than
+// a const so tests can lower it without needing multi-GiB test data.
+var maxArchiveSizeCeiling = int64(4 * 1024 * 1024 * 1024) // 4 GiB
+
+// maxDownloadSize bounds how much of a url- or source-sourced file install
+// step is buffered into memory, so an oversized or malicious response or
+// local file can't exhaust process memory before archive extraction limits
+// even apply. It's a var rather than a const so tests can lower it without
+// downloading 512MiB+.
 var maxDownloadSize = maxArchiveEntrySize
+
+// downloadTimeout bounds how long a url-sourced file install step's HTTP
+// request may run, closing the DoS gap that maxDownloadSize's size cap
+// leaves open against a slow or stalling server. It's a var rather than a
+// const so tests can lower it without waiting out the full timeout.
+var downloadTimeout = 5 * time.Minute
 
 // validArchiveType returns whether archiveType is a supported archive type
 // for the file install step
@@ -59,17 +82,41 @@ func extractArchiveFile(
 	archivePath string,
 	data []byte,
 ) ([]byte, error) {
+	return extractArchiveFileWithLimit(
+		archiveType,
+		archivePath,
+		data,
+		maxArchiveEntrySize,
+	)
+}
+
+// extractArchiveFileWithLimit is extractArchiveFile with an explicit size
+// bound, letting a file install step raise it via archiveMaxSize.
+func extractArchiveFileWithLimit(
+	archiveType string,
+	archivePath string,
+	data []byte,
+	maxSize int64,
+) ([]byte, error) {
 	switch strings.ToLower(archiveType) {
 	case archiveTypeZip:
-		return extractZipFile(archivePath, data)
+		return extractZipFileWithLimit(archivePath, data, maxSize)
 	case archiveTypeTarGz, archiveTypeTgz:
-		return extractTarGzFile(archivePath, data)
+		return extractTarGzFileWithLimit(archivePath, data, maxSize)
 	default:
 		return nil, fmt.Errorf("unsupported archive type %q", archiveType)
 	}
 }
 
 func extractZipFile(archivePath string, data []byte) ([]byte, error) {
+	return extractZipFileWithLimit(archivePath, data, maxArchiveEntrySize)
+}
+
+func extractZipFileWithLimit(
+	archivePath string,
+	data []byte,
+	maxSize int64,
+) ([]byte, error) {
 	zipReader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read zip archive: %w", err)
@@ -85,11 +132,11 @@ func extractZipFile(archivePath string, data []byte) ([]byte, error) {
 		if filepath.Clean(zipFile.Name) != cleanPath {
 			continue
 		}
-		if zipFile.UncompressedSize64 > uint64(maxArchiveEntrySize) {
+		if zipFile.UncompressedSize64 > uint64(maxSize) {
 			return nil, fmt.Errorf(
 				"file %q exceeds maximum allowed size of %d bytes",
 				archivePath,
-				maxArchiveEntrySize,
+				maxSize,
 			)
 		}
 		zf, err := zipFile.Open()
@@ -97,7 +144,7 @@ func extractZipFile(archivePath string, data []byte) ([]byte, error) {
 			return nil, err
 		}
 		defer zf.Close()
-		return readArchiveEntry(zf, archivePath, maxArchiveEntrySize)
+		return readArchiveEntry(zf, archivePath, maxSize)
 	}
 	return nil, fmt.Errorf("file %q not found in zip archive", archivePath)
 }
@@ -140,17 +187,17 @@ func extractTarGzFileWithLimit(
 		if filepath.Clean(header.Name) != cleanPath {
 			continue
 		}
-		if header.Size > maxArchiveEntrySize {
+		if header.Size > maxDecompressedSize {
 			return nil, fmt.Errorf(
 				"file %q exceeds maximum allowed size of %d bytes",
 				archivePath,
-				maxArchiveEntrySize,
+				maxDecompressedSize,
 			)
 		}
 		content, err := readArchiveEntry(
 			tarReader,
 			archivePath,
-			maxArchiveEntrySize,
+			maxDecompressedSize,
 		)
 		if err != nil {
 			return nil, err
@@ -216,8 +263,10 @@ func drainTarGzArchive(
 	return nil
 }
 
-// readArchiveEntry limits extraction even if an archive reports an incorrect
-// uncompressed size in its metadata.
+// readArchiveEntry reads from reader up to maxSize bytes, returning an error
+// if more remains. It's a generic bounded reader used for archive entries
+// (even when one reports an incorrect uncompressed size in its metadata), a
+// raw local file opened via source, and a raw HTTP response body.
 func readArchiveEntry(
 	reader io.Reader,
 	archivePath string,

--- a/pkgmgr/archive.go
+++ b/pkgmgr/archive.go
@@ -74,24 +74,11 @@ func validArchiveType(archiveType string) bool {
 	}
 }
 
-// extractArchiveFile returns the content of the file at archivePath within
-// the archive represented by data. The archive is expected to be in the
-// format specified by archiveType (zip, tar.gz, or tgz)
-func extractArchiveFile(
-	archiveType string,
-	archivePath string,
-	data []byte,
-) ([]byte, error) {
-	return extractArchiveFileWithLimit(
-		archiveType,
-		archivePath,
-		data,
-		maxArchiveEntrySize,
-	)
-}
-
-// extractArchiveFileWithLimit is extractArchiveFile with an explicit size
-// bound, letting a file install step raise it via archiveMaxSize.
+// extractArchiveFileWithLimit returns the content of the file at
+// archivePath within the archive represented by data, bounded by maxSize.
+// The archive is expected to be in the format specified by archiveType
+// (zip, tar.gz, or tgz). A file install step can raise maxSize for its own
+// archive via archiveMaxSize.
 func extractArchiveFileWithLimit(
 	archiveType string,
 	archivePath string,
@@ -108,15 +95,17 @@ func extractArchiveFileWithLimit(
 	}
 }
 
-func extractZipFile(archivePath string, data []byte) ([]byte, error) {
-	return extractZipFileWithLimit(archivePath, data, maxArchiveEntrySize)
-}
-
 func extractZipFileWithLimit(
 	archivePath string,
 	data []byte,
 	maxSize int64,
 ) ([]byte, error) {
+	if maxSize < 0 {
+		return nil, fmt.Errorf(
+			"invalid maxSize %d: must not be negative",
+			maxSize,
+		)
+	}
 	zipReader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read zip archive: %w", err)
@@ -147,14 +136,6 @@ func extractZipFileWithLimit(
 		return readArchiveEntry(zf, archivePath, maxSize)
 	}
 	return nil, fmt.Errorf("file %q not found in zip archive", archivePath)
-}
-
-func extractTarGzFile(archivePath string, data []byte) ([]byte, error) {
-	return extractTarGzFileWithLimit(
-		archivePath,
-		data,
-		maxArchiveEntrySize,
-	)
 }
 
 func extractTarGzFileWithLimit(

--- a/pkgmgr/archive_test.go
+++ b/pkgmgr/archive_test.go
@@ -94,7 +94,11 @@ func TestExtractZipFile(t *testing.T) {
 		"README.md":    "docs",
 	})
 
-	content, err := extractZipFile("bin/mybinary", data)
+	content, err := extractZipFileWithLimit(
+		"bin/mybinary",
+		data,
+		maxArchiveEntrySize,
+	)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -114,7 +118,8 @@ func TestExtractZipFileNotFound(t *testing.T) {
 		"bin/mybinary": testArchiveFileContent,
 	})
 
-	if _, err := extractZipFile("bin/missing", data); err == nil {
+	_, err := extractZipFileWithLimit("bin/missing", data, maxArchiveEntrySize)
+	if err == nil {
 		t.Fatal("expected error for missing file in archive, got nil")
 	}
 }
@@ -131,7 +136,8 @@ func TestExtractZipFileSkipsDirs(t *testing.T) {
 		t.Fatalf("unexpected error closing zip writer: %s", err)
 	}
 
-	if _, err := extractZipFile("bin", buf.Bytes()); err == nil {
+	_, err := extractZipFileWithLimit("bin", buf.Bytes(), maxArchiveEntrySize)
+	if err == nil {
 		t.Fatal("expected error when requested path is a directory, got nil")
 	}
 }
@@ -157,7 +163,12 @@ func TestExtractZipFileSkipsSymlinks(t *testing.T) {
 		t.Fatalf("unexpected error closing zip writer: %s", err)
 	}
 
-	if _, err := extractZipFile("bin/mybinary", buf.Bytes()); err == nil {
+	_, err = extractZipFileWithLimit(
+		"bin/mybinary",
+		buf.Bytes(),
+		maxArchiveEntrySize,
+	)
+	if err == nil {
 		t.Fatal("expected error when requested path is a symlink, got nil")
 	}
 }
@@ -170,7 +181,11 @@ func TestExtractTarGzFile(t *testing.T) {
 		"README.md":    "docs",
 	})
 
-	content, err := extractTarGzFile("bin/mybinary", data)
+	content, err := extractTarGzFileWithLimit(
+		"bin/mybinary",
+		data,
+		maxArchiveEntrySize,
+	)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -190,7 +205,12 @@ func TestExtractTarGzFileNotFound(t *testing.T) {
 		"bin/mybinary": testArchiveFileContent,
 	})
 
-	if _, err := extractTarGzFile("bin/missing", data); err == nil {
+	_, err := extractTarGzFileWithLimit(
+		"bin/missing",
+		data,
+		maxArchiveEntrySize,
+	)
+	if err == nil {
 		t.Fatal("expected error for missing file in archive, got nil")
 	}
 }
@@ -203,7 +223,12 @@ func TestExtractTarGzFileCorruptChecksum(t *testing.T) {
 	})
 	data[len(data)-8] ^= 0xff
 
-	if _, err := extractTarGzFile("bin/mybinary", data); err == nil {
+	_, err := extractTarGzFileWithLimit(
+		"bin/mybinary",
+		data,
+		maxArchiveEntrySize,
+	)
+	if err == nil {
 		t.Fatal("expected error for invalid gzip checksum, got nil")
 	}
 }
@@ -247,10 +272,11 @@ func TestExtractArchiveFileDispatch(t *testing.T) {
 		{archiveType: "tgz", data: tarGzData},
 	}
 	for _, testDef := range testDefs {
-		content, err := extractArchiveFile(
+		content, err := extractArchiveFileWithLimit(
 			testDef.archiveType,
 			"mybinary",
 			testDef.data,
+			maxArchiveEntrySize,
 		)
 		if err != nil {
 			t.Fatalf(
@@ -273,7 +299,13 @@ func TestExtractArchiveFileDispatch(t *testing.T) {
 // TestExtractArchiveFileUnsupportedType checks that extraction fails clearly
 // when an unsupported archive format is requested.
 func TestExtractArchiveFileUnsupportedType(t *testing.T) {
-	if _, err := extractArchiveFile("rar", "mybinary", nil); err == nil {
+	_, err := extractArchiveFileWithLimit(
+		"rar",
+		"mybinary",
+		nil,
+		maxArchiveEntrySize,
+	)
+	if err == nil {
 		t.Fatal("expected error for unsupported archive type, got nil")
 	}
 }

--- a/pkgmgr/archive_test.go
+++ b/pkgmgr/archive_test.go
@@ -228,8 +228,14 @@ func TestExtractTarGzFileCumulativeSizeLimit(t *testing.T) {
 // TestExtractArchiveFileDispatch checks that each supported archive name is
 // routed to the correct extractor, including aliases and different casing.
 func TestExtractArchiveFileDispatch(t *testing.T) {
-	zipData := buildTestZip(t, map[string]string{"mybinary": testArchiveFileContent})
-	tarGzData := buildTestTarGz(t, map[string]string{"mybinary": testArchiveFileContent})
+	zipData := buildTestZip(
+		t,
+		map[string]string{"mybinary": testArchiveFileContent},
+	)
+	tarGzData := buildTestTarGz(
+		t,
+		map[string]string{"mybinary": testArchiveFileContent},
+	)
 
 	testDefs := []struct {
 		archiveType string
@@ -241,7 +247,11 @@ func TestExtractArchiveFileDispatch(t *testing.T) {
 		{archiveType: "tgz", data: tarGzData},
 	}
 	for _, testDef := range testDefs {
-		content, err := extractArchiveFile(testDef.archiveType, "mybinary", testDef.data)
+		content, err := extractArchiveFile(
+			testDef.archiveType,
+			"mybinary",
+			testDef.data,
+		)
 		if err != nil {
 			t.Fatalf(
 				"unexpected error for archive type %q: %s",

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -1221,25 +1221,30 @@ func (p *PackageInstallStepDocker) deactivate(
 }
 
 type PackageInstallStepFile struct {
-	Binary      bool        `yaml:"binary"`
-	Filename    string      `yaml:"filename"`
-	Source      string      `yaml:"source"`
-	Content     string      `yaml:"content"`
-	Url         string      `yaml:"url"`
-	Mode        fs.FileMode `yaml:"mode,omitempty"`
-	Archive     string      `yaml:"archive,omitempty"`
-	ArchivePath string      `yaml:"archivePath,omitempty"`
+	Binary         bool        `yaml:"binary"`
+	Filename       string      `yaml:"filename"`
+	Source         string      `yaml:"source"`
+	Content        string      `yaml:"content"`
+	Url            string      `yaml:"url"`
+	Mode           fs.FileMode `yaml:"mode,omitempty"`
+	Archive        string      `yaml:"archive,omitempty"`
+	ArchivePath    string      `yaml:"archivePath,omitempty"`
+	ArchiveMaxSize int64       `yaml:"archiveMaxSize,omitempty"`
 }
 
 func (p *PackageInstallStepFile) validate(cfg Config) error {
 	if p.Content == "" && p.Source == "" && p.Url == "" {
 		cfg.Logger.Debug("file install step missing content, source, and url")
-		return errors.New("packages must provide content, source, or url for file install types")
+		return errors.New(
+			"packages must provide content, source, or url for file install types",
+		)
 	}
 	if p.Archive != "" {
 		if p.Content != "" {
 			cfg.Logger.Debug("archive combined with content")
-			return errors.New("archive cannot be combined with content; use source or url")
+			return errors.New(
+				"archive cannot be combined with content; use source or url",
+			)
 		}
 		if !validArchiveType(p.Archive) {
 			cfg.Logger.Debug("unsupported archive type: " + p.Archive)
@@ -1247,7 +1252,26 @@ func (p *PackageInstallStepFile) validate(cfg Config) error {
 		}
 		if p.ArchivePath == "" {
 			cfg.Logger.Debug("archive set without archivePath")
-			return errors.New("archivePath must be provided when archive is set")
+			return errors.New(
+				"archivePath must be provided when archive is set",
+			)
+		}
+	}
+	if p.ArchiveMaxSize != 0 {
+		if p.Archive == "" {
+			cfg.Logger.Debug("archiveMaxSize set without archive")
+			return errors.New("archiveMaxSize requires archive to be set")
+		}
+		if p.ArchiveMaxSize < 0 {
+			cfg.Logger.Debug("archiveMaxSize is negative")
+			return errors.New("archiveMaxSize must not be negative")
+		}
+		if p.ArchiveMaxSize > maxArchiveSizeCeiling {
+			cfg.Logger.Debug("archiveMaxSize exceeds ceiling")
+			return fmt.Errorf(
+				"archiveMaxSize exceeds maximum of %d bytes",
+				maxArchiveSizeCeiling,
+			)
 		}
 	}
 	return nil
@@ -1299,6 +1323,10 @@ func (p *PackageInstallStepFile) resolveContent(
 	cfg Config,
 	packagePath string,
 ) ([]byte, error) {
+	archiveMaxSize := maxArchiveEntrySize
+	if p.ArchiveMaxSize > 0 {
+		archiveMaxSize = p.ArchiveMaxSize
+	}
 	var fileContent []byte
 	if p.Content != "" {
 		tmpContent, err := cfg.Template.Render(p.Content, nil)
@@ -1321,7 +1349,11 @@ func (p *PackageInstallStepFile) resolveContent(
 				return nil, err
 			}
 			defer sourceFile.Close()
-			tmpContentBytes, err := readArchiveEntry(sourceFile, fullSourcePath, maxDownloadSize)
+			tmpContentBytes, err := readArchiveEntry(
+				sourceFile,
+				fullSourcePath,
+				maxDownloadSize,
+			)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read %q: %w", fullSourcePath, err)
 			}
@@ -1353,7 +1385,8 @@ func (p *PackageInstallStepFile) resolveContent(
 		}
 
 		// Fetch data
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), downloadTimeout)
+		defer cancel()
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, tmpUrl, nil)
 		if err != nil {
 			return nil, err
@@ -1373,16 +1406,27 @@ func (p *PackageInstallStepFile) resolveContent(
 
 		fileContent = respBody
 	} else {
-		return nil, errors.New("packages must provide content, source, or url for file install types")
+		return nil, errors.New(
+			"packages must provide content, source, or url for file install types",
+		)
 	}
 	if p.Archive != "" {
 		tmpArchivePath, err := cfg.Template.Render(p.ArchivePath, nil)
 		if err != nil {
 			return nil, err
 		}
-		fileContent, err = extractArchiveFile(p.Archive, tmpArchivePath, fileContent)
+		fileContent, err = extractArchiveFileWithLimit(
+			p.Archive,
+			tmpArchivePath,
+			fileContent,
+			archiveMaxSize,
+		)
 		if err != nil {
-			return nil, fmt.Errorf("failed to extract %q from archive: %w", tmpArchivePath, err)
+			return nil, fmt.Errorf(
+				"failed to extract %q from archive: %w",
+				tmpArchivePath,
+				err,
+			)
 		}
 	}
 	return fileContent, nil
@@ -1412,7 +1456,7 @@ func (p *PackageInstallStepFile) activate(cfg Config, pkgName string) error {
 		filePath := filepath.Join(
 			cfg.DataDir,
 			pkgName,
-			p.Filename,
+			tmpFilePath,
 		)
 		binPath := filepath.Join(
 			cfg.BinDir,

--- a/pkgmgr/package.go
+++ b/pkgmgr/package.go
@@ -1433,10 +1433,14 @@ func (p *PackageInstallStepFile) resolveContent(
 }
 
 func (p *PackageInstallStepFile) uninstall(cfg Config, pkgName string) error {
+	tmpFilePath, err := cfg.Template.Render(p.Filename, nil)
+	if err != nil {
+		return err
+	}
 	filePath := filepath.Join(
 		cfg.DataDir,
 		pkgName,
-		p.Filename,
+		tmpFilePath,
 	)
 	cfg.Logger.Debug("deleting file " + filePath)
 	if err := os.Remove(filePath); err != nil {

--- a/pkgmgr/package_archive_test.go
+++ b/pkgmgr/package_archive_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"testing"
 	"text/template"
+	"time"
 )
 
 func newArchiveTestConfig(t *testing.T) Config {
@@ -86,6 +87,40 @@ func TestPackageInstallStepFileValidate(t *testing.T) {
 			},
 			expectErr: true, // archive cannot be combined with content
 		},
+		{
+			step: PackageInstallStepFile{
+				Url:            "https://example.com/foo.zip",
+				Archive:        "zip",
+				ArchivePath:    "bin/foo",
+				ArchiveMaxSize: 1024,
+			},
+			expectErr: false,
+		},
+		{
+			step: PackageInstallStepFile{
+				Content:        "foo",
+				ArchiveMaxSize: 1024,
+			},
+			expectErr: true, // archiveMaxSize requires archive
+		},
+		{
+			step: PackageInstallStepFile{
+				Url:            "https://example.com/foo.zip",
+				Archive:        "zip",
+				ArchivePath:    "bin/foo",
+				ArchiveMaxSize: -1,
+			},
+			expectErr: true, // archiveMaxSize cannot be negative
+		},
+		{
+			step: PackageInstallStepFile{
+				Url:            "https://example.com/foo.zip",
+				Archive:        "zip",
+				ArchivePath:    "bin/foo",
+				ArchiveMaxSize: maxArchiveSizeCeiling + 1,
+			},
+			expectErr: true, // archiveMaxSize exceeds ceiling
+		},
 	}
 	cfg := newArchiveTestConfig(t)
 	for _, testDef := range testDefs {
@@ -99,8 +134,9 @@ func TestPackageInstallStepFileValidate(t *testing.T) {
 	}
 }
 
-// TestPackageInstallStepFileInstallArchiveZip checks that one binary is selected
-// from a ZIP archive, installed with its content, and linked on activation.
+// TestPackageInstallStepFileInstallArchiveZip checks that one binary is
+// selected from a ZIP archive, installed with its content, and linked on
+// activation.
 func TestPackageInstallStepFileInstallArchiveZip(t *testing.T) {
 	cfg := newArchiveTestConfig(t)
 	pkgSourceDir := t.TempDir()
@@ -142,6 +178,57 @@ func TestPackageInstallStepFileInstallArchiveZip(t *testing.T) {
 		t.Fatalf("activate failed: %s", err)
 	}
 	binPath := filepath.Join(cfg.BinDir, "mybinary")
+	linkTarget, err := os.Readlink(binPath)
+	if err != nil {
+		t.Fatalf("unexpected error reading symlink: %s", err)
+	}
+	if linkTarget != writtenPath {
+		t.Fatalf(
+			"symlink target mismatch\n  got: %s\n  expected: %s",
+			linkTarget,
+			writtenPath,
+		)
+	}
+}
+
+// TestPackageInstallStepFileActivateTemplatedFilename checks that activate()
+// symlinks to the same rendered path install() wrote the file at, when
+// filename contains a template expression. Regression test for a bug where
+// activate() built the symlink source from the raw, un-rendered filename
+// while the symlink destination used the rendered one, producing a dangling
+// symlink for any package using a per-OS/ARCH templated filename.
+func TestPackageInstallStepFileActivateTemplatedFilename(t *testing.T) {
+	cfg := newArchiveTestConfig(t)
+	cfg.Template = cfg.Template.WithVars(
+		map[string]any{
+			"System": map[string]string{
+				"OS": "linux",
+			},
+		},
+	)
+	step := &PackageInstallStepFile{
+		Filename: "{{ .System.OS }}-mybinary",
+		Content:  testArchiveFileContent,
+		Binary:   true,
+		Mode:     0o755,
+	}
+	if err := step.install(cfg, "test-1.0.0-testctx", ""); err != nil {
+		t.Fatalf("install failed: %s", err)
+	}
+
+	writtenPath := filepath.Join(
+		cfg.DataDir,
+		"test-1.0.0-testctx",
+		"linux-mybinary",
+	)
+	if _, err := os.Stat(writtenPath); err != nil {
+		t.Fatalf("expected installed file at %s: %s", writtenPath, err)
+	}
+
+	if err := step.activate(cfg, "test-1.0.0-testctx"); err != nil {
+		t.Fatalf("activate failed: %s", err)
+	}
+	binPath := filepath.Join(cfg.BinDir, "linux-mybinary")
 	linkTarget, err := os.Readlink(binPath)
 	if err != nil {
 		t.Fatalf("unexpected error reading symlink: %s", err)
@@ -266,13 +353,15 @@ func TestPackageInstallStepFileInstallUrlArchive(t *testing.T) {
 	tarGzData := buildTestTarGz(t, map[string]string{
 		"mybinary": testArchiveFileContent,
 	})
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/releases/mybinary-linux-amd64.tar.gz" {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-		w.Write(tarGzData) //nolint:errcheck
-	}))
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/releases/mybinary-linux-amd64.tar.gz" {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Write(tarGzData) //nolint:errcheck
+		}),
+	)
 	defer srv.Close()
 
 	cfg := newArchiveTestConfig(t)
@@ -286,10 +375,11 @@ func TestPackageInstallStepFileInstallUrlArchive(t *testing.T) {
 	)
 
 	step := &PackageInstallStepFile{
-		Filename:    "mybinary",
-		Binary:      true,
-		Mode:        0o755,
-		Url:         srv.URL + "/releases/mybinary-{{ .System.OS }}-{{ .System.ARCH }}.tar.gz",
+		Filename: "mybinary",
+		Binary:   true,
+		Mode:     0o755,
+		Url: srv.URL +
+			"/releases/mybinary-{{ .System.OS }}-{{ .System.ARCH }}.tar.gz",
 		Archive:     "tar.gz",
 		ArchivePath: "mybinary",
 	}
@@ -337,9 +427,11 @@ func TestPackageInstallStepFileInstallUrlDownloadSizeLimit(t *testing.T) {
 		maxDownloadSize = origMaxDownloadSize
 	})
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(strings.Repeat("x", 100))) //nolint:errcheck
-	}))
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(strings.Repeat("x", 100))) //nolint:errcheck
+		}),
+	)
 	defer srv.Close()
 
 	cfg := newArchiveTestConfig(t)
@@ -355,6 +447,43 @@ func TestPackageInstallStepFileInstallUrlDownloadSizeLimit(t *testing.T) {
 	writtenPath := filepath.Join(cfg.DataDir, "test-1.0.0-testctx", "mybinary")
 	if _, statErr := os.Stat(writtenPath); statErr == nil {
 		t.Fatal("expected no file to be written for oversized download")
+	}
+}
+
+// TestPackageInstallStepFileInstallUrlDownloadTimeout checks that install
+// aborts a url-sourced download once it exceeds downloadTimeout, instead of
+// hanging indefinitely against a slow or stalling server.
+func TestPackageInstallStepFileInstallUrlDownloadTimeout(t *testing.T) {
+	origDownloadTimeout := downloadTimeout
+	downloadTimeout = 10 * time.Millisecond
+	t.Cleanup(func() {
+		downloadTimeout = origDownloadTimeout
+	})
+
+	blockCh := make(chan struct{})
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			<-blockCh
+		}),
+	)
+	defer func() {
+		close(blockCh)
+		srv.Close()
+	}()
+
+	cfg := newArchiveTestConfig(t)
+	step := &PackageInstallStepFile{
+		Filename: "mybinary",
+		Url:      srv.URL + "/mybinary",
+	}
+	err := step.install(cfg, "test-1.0.0-testctx", "")
+	if err == nil {
+		t.Fatal("expected error for a download exceeding the timeout, got nil")
+	}
+
+	writtenPath := filepath.Join(cfg.DataDir, "test-1.0.0-testctx", "mybinary")
+	if _, statErr := os.Stat(writtenPath); statErr == nil {
+		t.Fatal("expected no file to be written for a timed-out download")
 	}
 }
 
@@ -410,10 +539,12 @@ func TestPackageInstallStepFileInstallArchivePathTemplated(t *testing.T) {
 func TestPackageInstallStepFileInstallUrlTemplated(t *testing.T) {
 	const expectedContent = "binary content"
 	var requestedPath string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestedPath = r.URL.Path
-		w.Write([]byte(expectedContent)) //nolint:errcheck
-	}))
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestedPath = r.URL.Path
+			w.Write([]byte(expectedContent)) //nolint:errcheck
+		}),
+	)
 	defer srv.Close()
 
 	cfg := newArchiveTestConfig(t)
@@ -495,8 +626,126 @@ func TestPackageInstallStepFileInstallSourceArchiveSizeLimit(t *testing.T) {
 	}
 }
 
-// TestPackageInstallStepFileInstallArchiveModePreserved checks that the requested
-// file permissions are applied to the binary extracted from an archive.
+// TestPackageInstallStepFileInstallArchiveMaxSizeOverride checks that a
+// package-level archiveMaxSize is actually applied to extraction, by setting
+// it below the size of an entry that would otherwise pass under the default
+// maxArchiveEntrySize.
+func TestPackageInstallStepFileInstallArchiveMaxSizeOverride(t *testing.T) {
+	cfg := newArchiveTestConfig(t)
+	pkgSourceDir := t.TempDir()
+	tarGzPath := filepath.Join(pkgSourceDir, "release.tar.gz")
+	tarGzData := buildTestTarGz(t, map[string]string{
+		"mybinary": testArchiveFileContent,
+	})
+	if err := os.WriteFile(tarGzPath, tarGzData, 0o644); err != nil {
+		t.Fatalf("unexpected error writing test tar.gz: %s", err)
+	}
+
+	step := &PackageInstallStepFile{
+		Filename:       "mybinary",
+		Source:         "release.tar.gz",
+		Archive:        "tar.gz",
+		ArchivePath:    "mybinary",
+		ArchiveMaxSize: int64(len(testArchiveFileContent)) - 1,
+	}
+	packagePath := filepath.Join(pkgSourceDir, "test-1.0.0.yaml")
+	err := step.install(cfg, "test-1.0.0-testctx", packagePath)
+	if err == nil {
+		t.Fatal("expected error from archiveMaxSize override, got nil")
+	}
+
+	writtenPath := filepath.Join(cfg.DataDir, "test-1.0.0-testctx", "mybinary")
+	if _, statErr := os.Stat(writtenPath); statErr == nil {
+		t.Fatal(
+			"expected no file to be written when archiveMaxSize is exceeded",
+		)
+	}
+}
+
+// TestPackageInstallStepFileInstallArchiveMaxSizeAllowsLargerEntry checks
+// that raising archiveMaxSize permits extracting an entry that exceeds the
+// default maxArchiveEntrySize, proving the override actually reaches the
+// extraction path rather than the default silently still applying. It lowers
+// maxArchiveEntrySize itself so the "large" entry can stay tiny.
+func TestPackageInstallStepFileInstallArchiveMaxSizeAllowsLargerEntry(
+	t *testing.T,
+) {
+	origMaxArchiveEntrySize := maxArchiveEntrySize
+	maxArchiveEntrySize = 10
+	t.Cleanup(func() {
+		maxArchiveEntrySize = origMaxArchiveEntrySize
+	})
+
+	cfg := newArchiveTestConfig(t)
+	pkgSourceDir := t.TempDir()
+	tarGzPath := filepath.Join(pkgSourceDir, "release.tar.gz")
+	tarGzData := buildTestTarGz(t, map[string]string{
+		"mybinary": testArchiveFileContent, // 21 bytes, exceeds the lowered default
+	})
+	if err := os.WriteFile(tarGzPath, tarGzData, 0o644); err != nil {
+		t.Fatalf("unexpected error writing test tar.gz: %s", err)
+	}
+
+	step := &PackageInstallStepFile{
+		Filename:       "mybinary",
+		Source:         "release.tar.gz",
+		Archive:        "tar.gz",
+		ArchivePath:    "mybinary",
+		ArchiveMaxSize: 4096,
+	}
+	packagePath := filepath.Join(pkgSourceDir, "test-1.0.0.yaml")
+	if err := step.install(cfg, "test-1.0.0-testctx", packagePath); err != nil {
+		t.Fatalf("install failed despite archiveMaxSize override: %s", err)
+	}
+
+	writtenPath := filepath.Join(cfg.DataDir, "test-1.0.0-testctx", "mybinary")
+	content, err := os.ReadFile(writtenPath)
+	if err != nil {
+		t.Fatalf("unexpected error reading installed file: %s", err)
+	}
+	if string(content) != testArchiveFileContent {
+		t.Fatal("installed content did not match the archive entry")
+	}
+}
+
+// TestPackageInstallStepFileInstallArchiveMaxSizeDefaultStillApplies checks
+// that without an override, an entry exceeding the (lowered, for the test)
+// default maxArchiveEntrySize is still rejected, so the prior test's success
+// is actually due to the override and not a bypassed check.
+func TestPackageInstallStepFileInstallArchiveMaxSizeDefaultStillApplies(
+	t *testing.T,
+) {
+	origMaxArchiveEntrySize := maxArchiveEntrySize
+	maxArchiveEntrySize = 10
+	t.Cleanup(func() {
+		maxArchiveEntrySize = origMaxArchiveEntrySize
+	})
+
+	cfg := newArchiveTestConfig(t)
+	pkgSourceDir := t.TempDir()
+	tarGzPath := filepath.Join(pkgSourceDir, "release.tar.gz")
+	tarGzData := buildTestTarGz(t, map[string]string{
+		"mybinary": testArchiveFileContent, // 21 bytes, exceeds the lowered default
+	})
+	if err := os.WriteFile(tarGzPath, tarGzData, 0o644); err != nil {
+		t.Fatalf("unexpected error writing test tar.gz: %s", err)
+	}
+
+	step := &PackageInstallStepFile{
+		Filename:    "mybinary",
+		Source:      "release.tar.gz",
+		Archive:     "tar.gz",
+		ArchivePath: "mybinary",
+	}
+	packagePath := filepath.Join(pkgSourceDir, "test-1.0.0.yaml")
+	if err := step.install(cfg, "test-1.0.0-testctx", packagePath); err == nil {
+		t.Fatal("expected error without archiveMaxSize override, got nil")
+	}
+}
+
+// TestPackageInstallStepFileInstallArchiveModePreserved checks that the
+// requested file permissions are applied to the binary extracted from an
+// archive.
 func TestPackageInstallStepFileInstallArchiveModePreserved(t *testing.T) {
 	cfg := newArchiveTestConfig(t)
 	pkgSourceDir := t.TempDir()

--- a/pkgmgr/package_archive_test.go
+++ b/pkgmgr/package_archive_test.go
@@ -245,6 +245,52 @@ func TestPackageInstallStepFileActivateTemplatedFilename(t *testing.T) {
 	}
 }
 
+// TestPackageInstallStepFileUninstallTemplatedFilename checks that
+// uninstall() removes the same rendered path install() wrote the file at,
+// when filename contains a template expression. Regression test for a bug
+// where uninstall() built the delete path from the raw, un-rendered
+// filename, so the actual rendered file (e.g. binary-linux) was never
+// removed - os.Remove silently no-ops on the literal, nonexistent
+// "{{ .System.OS }}"-suffixed path instead of erroring.
+func TestPackageInstallStepFileUninstallTemplatedFilename(t *testing.T) {
+	cfg := newArchiveTestConfig(t)
+	cfg.Template = cfg.Template.WithVars(
+		map[string]any{
+			"System": map[string]string{
+				"OS": "linux",
+			},
+		},
+	)
+	step := &PackageInstallStepFile{
+		Filename: "{{ .System.OS }}-mybinary",
+		Content:  testArchiveFileContent,
+		Binary:   true,
+		Mode:     0o755,
+	}
+	if err := step.install(cfg, "test-1.0.0-testctx", ""); err != nil {
+		t.Fatalf("install failed: %s", err)
+	}
+	writtenPath := filepath.Join(
+		cfg.DataDir,
+		"test-1.0.0-testctx",
+		"linux-mybinary",
+	)
+	if _, err := os.Stat(writtenPath); err != nil {
+		t.Fatalf("expected installed file at %s: %s", writtenPath, err)
+	}
+
+	if err := step.uninstall(cfg, "test-1.0.0-testctx"); err != nil {
+		t.Fatalf("uninstall failed: %s", err)
+	}
+	if _, err := os.Stat(writtenPath); !os.IsNotExist(err) {
+		t.Fatalf(
+			"expected rendered file %s to be removed by uninstall, stat err: %v",
+			writtenPath,
+			err,
+		)
+	}
+}
+
 // TestPackageInstallStepFileInstallArchiveTarGz checks that one binary can be
 // selected from a tar.gz archive and written to the package data directory.
 func TestPackageInstallStepFileInstallArchiveTarGz(t *testing.T) {

--- a/pkgmgr/package_archive_test.go
+++ b/pkgmgr/package_archive_test.go
@@ -15,6 +15,8 @@
 package pkgmgr
 
 import (
+	"context"
+	"errors"
 	"io/fs"
 	"log/slog"
 	"net/http"
@@ -22,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"text/template"
 	"time"
@@ -452,7 +455,12 @@ func TestPackageInstallStepFileInstallUrlDownloadSizeLimit(t *testing.T) {
 
 // TestPackageInstallStepFileInstallUrlDownloadTimeout checks that install
 // aborts a url-sourced download once it exceeds downloadTimeout, instead of
-// hanging indefinitely against a slow or stalling server.
+// hanging indefinitely against a slow or stalling server. install() is run
+// in a goroutine under a bounded watchdog: without the production timeout
+// in place, the test server's handler blocks forever (it's only released
+// by closeBlock, which a broken fix would never let this test reach), so a
+// direct, synchronous call would hang until the whole test binary's global
+// timeout instead of failing this test with a clear message.
 func TestPackageInstallStepFileInstallUrlDownloadTimeout(t *testing.T) {
 	origDownloadTimeout := downloadTimeout
 	downloadTimeout = 10 * time.Millisecond
@@ -461,13 +469,15 @@ func TestPackageInstallStepFileInstallUrlDownloadTimeout(t *testing.T) {
 	})
 
 	blockCh := make(chan struct{})
+	var closeBlockOnce sync.Once
+	closeBlock := func() { closeBlockOnce.Do(func() { close(blockCh) }) }
 	srv := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			<-blockCh
 		}),
 	)
 	defer func() {
-		close(blockCh)
+		closeBlock()
 		srv.Close()
 	}()
 
@@ -476,9 +486,27 @@ func TestPackageInstallStepFileInstallUrlDownloadTimeout(t *testing.T) {
 		Filename: "mybinary",
 		Url:      srv.URL + "/mybinary",
 	}
-	err := step.install(cfg, "test-1.0.0-testctx", "")
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- step.install(cfg, "test-1.0.0-testctx", "")
+	}()
+
+	var err error
+	select {
+	case err = <-errCh:
+	case <-time.After(5 * time.Second):
+		closeBlock()
+		t.Fatal(
+			"install() did not return within the watchdog window; " +
+				"the production download timeout does not appear to be enforced",
+		)
+	}
 	if err == nil {
 		t.Fatal("expected error for a download exceeding the timeout, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected a context.DeadlineExceeded error, got: %v", err)
 	}
 
 	writtenPath := filepath.Join(cfg.DataDir, "test-1.0.0-testctx", "mybinary")

--- a/pkgmgr/pkgmgr.go
+++ b/pkgmgr/pkgmgr.go
@@ -243,6 +243,16 @@ func (p *PackageManager) Install(pkgs ...string) error {
 	if err != nil {
 		return err
 	}
+	// Validate every package in the resolved plan before installing any of
+	// them, since the registry may have loaded them without validation (see
+	// loadPackageRegistry). Validating inside the loop below would let
+	// earlier entries in the plan - e.g. resolved dependencies - install
+	// and persist successfully before a later, invalid entry is rejected.
+	for _, installPkg := range installPkgs {
+		if err := installPkg.Install.validate(p.config); err != nil {
+			return fmt.Errorf("package validation failed: %w", err)
+		}
+	}
 	installedPkgs := []string{}
 	var sb strings.Builder
 	for _, installPkg := range installPkgs {
@@ -253,11 +263,6 @@ func (p *PackageManager) Install(pkgs ...string) error {
 				installPkg.Install.Version,
 			),
 		)
-		// Validate package before installing, since the registry may have
-		// loaded it without validation (see loadPackageRegistry)
-		if err := installPkg.Install.validate(p.config); err != nil {
-			return fmt.Errorf("package validation failed: %w", err)
-		}
 		// Build package options
 		tmpPkgOpts := installPkg.Install.defaultOpts()
 		maps.Copy(tmpPkgOpts, installPkg.Options)
@@ -340,6 +345,17 @@ func (p *PackageManager) Upgrade(pkgs ...string) error {
 	if err != nil {
 		return err
 	}
+	// Validate every new package version in the resolved plan before
+	// deactivating/uninstalling any currently-installed version, since the
+	// registry may have loaded them without validation (see
+	// loadPackageRegistry). Validating inside the loop below would let
+	// earlier entries in the plan tear down and replace their old version
+	// before a later, invalid entry is rejected.
+	for _, upgradePkg := range upgradePkgs {
+		if err := upgradePkg.Upgrade.validate(p.config); err != nil {
+			return fmt.Errorf("package validation failed: %w", err)
+		}
+	}
 	installedPkgs := []string{}
 	var sb strings.Builder
 	for _, upgradePkg := range upgradePkgs {
@@ -351,11 +367,6 @@ func (p *PackageManager) Upgrade(pkgs ...string) error {
 				upgradePkg.Upgrade.Version,
 			),
 		)
-		// Validate new package before upgrading, since the registry may have
-		// loaded it without validation (see loadPackageRegistry)
-		if err := upgradePkg.Upgrade.validate(p.config); err != nil {
-			return fmt.Errorf("package validation failed: %w", err)
-		}
 		// Capture options from existing package
 		pkgOpts := upgradePkg.Installed.Options
 		registeredPorts := p.registeredPorts(contextName, upgradePkg.Installed.Package.Name)

--- a/pkgmgr/pkgmgr.go
+++ b/pkgmgr/pkgmgr.go
@@ -253,6 +253,11 @@ func (p *PackageManager) Install(pkgs ...string) error {
 				installPkg.Install.Version,
 			),
 		)
+		// Validate package before installing, since the registry may have
+		// loaded it without validation (see loadPackageRegistry)
+		if err := installPkg.Install.validate(p.config); err != nil {
+			return fmt.Errorf("package validation failed: %w", err)
+		}
 		// Build package options
 		tmpPkgOpts := installPkg.Install.defaultOpts()
 		maps.Copy(tmpPkgOpts, installPkg.Options)
@@ -346,6 +351,11 @@ func (p *PackageManager) Upgrade(pkgs ...string) error {
 				upgradePkg.Upgrade.Version,
 			),
 		)
+		// Validate new package before upgrading, since the registry may have
+		// loaded it without validation (see loadPackageRegistry)
+		if err := upgradePkg.Upgrade.validate(p.config); err != nil {
+			return fmt.Errorf("package validation failed: %w", err)
+		}
 		// Capture options from existing package
 		pkgOpts := upgradePkg.Installed.Options
 		registeredPorts := p.registeredPorts(contextName, upgradePkg.Installed.Package.Name)

--- a/pkgmgr/pkgmgr_install_test.go
+++ b/pkgmgr/pkgmgr_install_test.go
@@ -123,8 +123,9 @@ func TestUpgradeRejectsInvalidNewPackageVersion(t *testing.T) {
 	}
 	pm.availablePackages = []Package{
 		{
-			Name:    "pkg",
-			Version: "2.0.0",
+			Name:     "pkg",
+			Version:  "2.0.0",
+			filePath: filepath.Join("pkg", "pkg-2.0.0.yaml"),
 			InstallSteps: []PackageInstallStep{
 				{
 					// Missing content/source/url; caught by

--- a/pkgmgr/pkgmgr_install_test.go
+++ b/pkgmgr/pkgmgr_install_test.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -295,6 +296,85 @@ func TestUpgradeValidatesEntirePlanBeforeMutatingAny(t *testing.T) {
 		t.Fatalf(
 			"expected app to remain at its original version, got: %#v",
 			pm.state.InstalledPackages,
+		)
+	}
+}
+
+// TestUpgradeRemovesOldTemplatedFilenameFile is a production-shaped
+// Install-then-Upgrade probe for a package with a templated (e.g.
+// per-OS/ARCH) binary filename. Upgrade() calls uninstallPackage with
+// keepData=true, which skips the old version's whole data-directory
+// removal, so the old rendered file (e.g. binary-linux) is left behind
+// unless PackageInstallStepFile.uninstall() itself removes the correct,
+// rendered path - which it didn't, since it built the delete path from the
+// raw, un-rendered filename.
+func TestUpgradeRemovesOldTemplatedFilenameFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := Config{
+		DataDir:   filepath.Join(tmpDir, "data"),
+		CacheDir:  filepath.Join(tmpDir, "cache"),
+		ConfigDir: filepath.Join(tmpDir, "config"),
+		BinDir:    filepath.Join(tmpDir, "bin"),
+		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Template:  NewTemplate(nil),
+	}
+	pm := &PackageManager{
+		config: cfg,
+		state: &State{
+			config:        cfg,
+			ActiveContext: "default",
+			Contexts: map[string]Context{
+				"default": {Network: "preprod"},
+			},
+			PortRegistry: make(PortRegistry),
+		},
+	}
+	installStep := func() PackageInstallStep {
+		return PackageInstallStep{
+			File: &PackageInstallStepFile{
+				Filename: "binary-{{ .System.OS }}",
+				Binary:   true,
+				Content:  "hello",
+				Mode:     0o755,
+			},
+		}
+	}
+	pm.availablePackages = []Package{
+		{
+			Name:         "app",
+			Version:      "1.0.0",
+			filePath:     filepath.Join("app", "app-1.0.0.yaml"),
+			InstallSteps: []PackageInstallStep{installStep()},
+		},
+	}
+
+	if err := pm.Install("app"); err != nil {
+		t.Fatalf("install failed: %s", err)
+	}
+	oldFilePath := filepath.Join(
+		cfg.DataDir,
+		"app-1.0.0-default",
+		"binary-"+runtime.GOOS,
+	)
+	if _, err := os.Stat(oldFilePath); err != nil {
+		t.Fatalf("expected installed file at %s: %s", oldFilePath, err)
+	}
+
+	pm.availablePackages = append(pm.availablePackages, Package{
+		Name:         "app",
+		Version:      "2.0.0",
+		filePath:     filepath.Join("app", "app-2.0.0.yaml"),
+		InstallSteps: []PackageInstallStep{installStep()},
+	})
+	if err := pm.Upgrade("app"); err != nil {
+		t.Fatalf("upgrade failed: %s", err)
+	}
+
+	if _, err := os.Stat(oldFilePath); !os.IsNotExist(err) {
+		t.Fatalf(
+			"expected old rendered file %s to be removed after upgrade, stat err: %v",
+			oldFilePath,
+			err,
 		)
 	}
 }

--- a/pkgmgr/pkgmgr_install_test.go
+++ b/pkgmgr/pkgmgr_install_test.go
@@ -149,3 +149,152 @@ func TestUpgradeRejectsInvalidNewPackageVersion(t *testing.T) {
 		)
 	}
 }
+
+// TestInstallValidatesEntirePlanBeforeInstallingAny checks that Install()
+// validates every package in the resolved plan before installing any of
+// them. Without this, "app" depending on "dep" would install and persist
+// "dep" (processed first in the resolved plan) before ever validating the
+// invalid "app" itself, leaving a resolved dependency installed despite the
+// overall command failing.
+func TestInstallValidatesEntirePlanBeforeInstallingAny(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := Config{
+		DataDir:   filepath.Join(tmpDir, "data"),
+		CacheDir:  filepath.Join(tmpDir, "cache"),
+		ConfigDir: filepath.Join(tmpDir, "config"),
+		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Template:  NewTemplate(nil),
+	}
+	pm := &PackageManager{
+		config: cfg,
+		state: &State{
+			config:        cfg,
+			ActiveContext: "default",
+			Contexts: map[string]Context{
+				"default": {Network: "preprod"},
+			},
+			PortRegistry: make(PortRegistry),
+		},
+	}
+	pm.availablePackages = []Package{
+		{
+			Name:     "dep",
+			Version:  "1.0.0",
+			filePath: filepath.Join("dep", "dep-1.0.0.yaml"),
+			InstallSteps: []PackageInstallStep{
+				{
+					File: &PackageInstallStepFile{
+						Filename: "output",
+						Content:  "hello",
+					},
+				},
+			},
+		},
+		{
+			// invalid: missing filePath, so Package.validate rejects it
+			Name:         "app",
+			Version:      "1.0.0",
+			Dependencies: []string{"dep"},
+			InstallSteps: []PackageInstallStep{
+				{
+					File: &PackageInstallStepFile{
+						Filename: "output",
+						Content:  "hello",
+					},
+				},
+			},
+		},
+	}
+
+	if err := pm.Install("app"); err == nil {
+		t.Fatal("expected install to fail validation, got nil error")
+	}
+	if len(pm.state.InstalledPackages) != 0 {
+		t.Fatalf(
+			"expected no installed packages (including resolved "+
+				"dependencies) after failed validation, got: %#v",
+			pm.state.InstalledPackages,
+		)
+	}
+}
+
+// TestUpgradeValidatesEntirePlanBeforeMutatingAny checks that Upgrade()
+// validates every package in the resolved plan before deactivating,
+// uninstalling, or installing any of them. Without this, upgrading "app"
+// (processed first in the resolved plan) would tear down its old version
+// and install the new one before ever validating the invalid new
+// dependency "newdep" the new version pulls in.
+func TestUpgradeValidatesEntirePlanBeforeMutatingAny(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := Config{
+		DataDir:   filepath.Join(tmpDir, "data"),
+		CacheDir:  filepath.Join(tmpDir, "cache"),
+		ConfigDir: filepath.Join(tmpDir, "config"),
+		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Template:  NewTemplate(nil),
+	}
+	installedApp := Package{
+		Name:     "app",
+		Version:  "1.0.0",
+		filePath: filepath.Join("app", "app-1.0.0.yaml"),
+	}
+	pm := &PackageManager{
+		config: cfg,
+		state: &State{
+			config:        cfg,
+			ActiveContext: "default",
+			Contexts: map[string]Context{
+				"default": {Network: "preprod"},
+			},
+			InstalledPackages: []InstalledPackage{
+				{
+					Package:       installedApp,
+					InstalledTime: time.Now(),
+					Context:       "default",
+					Options:       map[string]bool{},
+				},
+			},
+			PortRegistry: make(PortRegistry),
+		},
+	}
+	pm.availablePackages = []Package{
+		{
+			Name:         "app",
+			Version:      "2.0.0",
+			filePath:     filepath.Join("app", "app-2.0.0.yaml"),
+			Dependencies: []string{"newdep"},
+			InstallSteps: []PackageInstallStep{
+				{
+					File: &PackageInstallStepFile{
+						Filename: "output",
+						Content:  "hello",
+					},
+				},
+			},
+		},
+		{
+			// invalid: missing filePath, so Package.validate rejects it
+			Name:    "newdep",
+			Version: "1.0.0",
+			InstallSteps: []PackageInstallStep{
+				{
+					File: &PackageInstallStepFile{
+						Filename: "output",
+						Content:  "hello",
+					},
+				},
+			},
+		},
+	}
+
+	if err := pm.Upgrade("app"); err == nil {
+		t.Fatal("expected upgrade to fail validation, got nil error")
+	}
+	if len(pm.state.InstalledPackages) != 1 ||
+		pm.state.InstalledPackages[0].Package.Version != "1.0.0" {
+		t.Fatalf(
+			"expected app to remain at its original version, got: %#v",
+			pm.state.InstalledPackages,
+		)
+	}
+}

--- a/pkgmgr/pkgmgr_install_test.go
+++ b/pkgmgr/pkgmgr_install_test.go
@@ -1,0 +1,150 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkgmgr
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestInstallRejectsInvalidPackage checks that PackageManager.Install() runs
+// package validation before performing any install steps. Packages loaded
+// through AvailablePackages() are not validated (see loadPackageRegistry),
+// so without this check an invalid package (here, one with a name containing
+// characters disallowed by Package.validate()) would otherwise install
+// successfully.
+func TestInstallRejectsInvalidPackage(t *testing.T) {
+	tmpDir := t.TempDir()
+	pm := &PackageManager{
+		config: Config{
+			DataDir:  filepath.Join(tmpDir, "data"),
+			CacheDir: filepath.Join(tmpDir, "cache"),
+			Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+			Template: NewTemplate(nil),
+		},
+		state: &State{
+			ActiveContext: "default",
+			Contexts: map[string]Context{
+				"default": {Network: "preprod"},
+			},
+			PortRegistry: make(PortRegistry),
+		},
+	}
+	pm.availablePackages = []Package{
+		{
+			Name:    "bad_pkg",
+			Version: "1.0.0",
+			InstallSteps: []PackageInstallStep{
+				{
+					File: &PackageInstallStepFile{
+						Filename: "output",
+						Content:  "hello",
+					},
+				},
+			},
+		},
+	}
+
+	if err := pm.Install("bad_pkg"); err == nil {
+		t.Fatal("expected install to fail validation, got nil error")
+	}
+	if len(pm.state.InstalledPackages) != 0 {
+		t.Fatalf(
+			"expected no installed packages after failed validation, got: %#v",
+			pm.state.InstalledPackages,
+		)
+	}
+	writtenPath := filepath.Join(
+		pm.config.DataDir,
+		"bad_pkg-1.0.0-default",
+		"output",
+	)
+	if _, err := os.Stat(writtenPath); !os.IsNotExist(err) {
+		t.Fatalf(
+			"expected no file written for a package that failed validation, got err: %v",
+			err,
+		)
+	}
+}
+
+// TestUpgradeRejectsInvalidNewPackageVersion checks that PackageManager.
+// Upgrade() validates the target package before deactivating and
+// uninstalling the currently installed version. Without this check, an
+// invalid upgrade target (here, a file install step missing content,
+// source, and url) would still fail inside install(), but only after the
+// working, installed version had already been torn down.
+func TestUpgradeRejectsInvalidNewPackageVersion(t *testing.T) {
+	tmpDir := t.TempDir()
+	installedPkg := Package{
+		Name:    "pkg",
+		Version: "1.0.0",
+	}
+	pm := &PackageManager{
+		config: Config{
+			DataDir:  filepath.Join(tmpDir, "data"),
+			CacheDir: filepath.Join(tmpDir, "cache"),
+			Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+			Template: NewTemplate(nil),
+		},
+		state: &State{
+			ActiveContext: "default",
+			Contexts: map[string]Context{
+				"default": {Network: "preprod"},
+			},
+			InstalledPackages: []InstalledPackage{
+				{
+					Package: installedPkg,
+					// InstalledPackage.IsEmpty() checks InstalledTime, not
+					// the embedded Package fields, so this must be set for
+					// the resolver to recognize this as already installed.
+					InstalledTime: time.Now(),
+					Context:       "default",
+					Options:       map[string]bool{},
+				},
+			},
+			PortRegistry: make(PortRegistry),
+		},
+	}
+	pm.availablePackages = []Package{
+		{
+			Name:    "pkg",
+			Version: "2.0.0",
+			InstallSteps: []PackageInstallStep{
+				{
+					// Missing content/source/url; caught by
+					// PackageInstallStepFile.validate().
+					File: &PackageInstallStepFile{
+						Filename: "output",
+					},
+				},
+			},
+		},
+	}
+
+	if err := pm.Upgrade("pkg"); err == nil {
+		t.Fatal("expected upgrade to fail validation, got nil error")
+	}
+	if len(pm.state.InstalledPackages) != 1 ||
+		pm.state.InstalledPackages[0].Package.Version != "1.0.0" {
+		t.Fatalf(
+			"expected the original version to remain installed, got: %#v",
+			pm.state.InstalledPackages,
+		)
+	}
+}


### PR DESCRIPTION
## Summary

Addresses every item from #562 ("Follow-ups from PR #561 review: pre-existing gaps and cleanup") — three pre-existing bugs adjacent to the ZIP/tar.gz binary-install feature, the open design question about the decompression cap, and the doc/line-length cleanup.

- **`activate()` used the un-rendered filename for the symlink source.** A package with a templated (e.g. per-OS/ARCH) `filename` would get a dangling symlink, since the symlink source path used the raw template string while the destination used the rendered one.
- **`validate()` never ran on the real install path.** `PackageManager.Install()`/`Upgrade()` called `install()` directly; the friendly validation errors (including the archive checks from #561) only ever fired via the separate `cardano-up validate` command. In `Upgrade()` specifically, this meant a bad new version could tear down the working installed version *before* the failure surfaced.
- **URL downloads had no timeout.** `context.Background()` + `http.DefaultClient` had no deadline, so a slow/stalling server could hang an install indefinitely despite the existing size cap.
- **tar.gz decompression cap was whole-archive with no override.** A small target binary inside a large-but-legitimate multi-arch/bundle release (docs, samples, other platforms) could fail to install purely because the *whole* archive decompressed past 512 MiB. Added an optional, bounded per-package override.
- Doc-comment and pre-existing (introduced in #561) line-length cleanup.

## Changes file by file

**`pkgmgr/package.go`**
- `PackageInstallStepFile.activate()`: symlink source now built from the template-rendered filename (`tmpFilePath`) instead of the raw `p.Filename`, matching the destination path.
- `PackageInstallStepFile.validate()`: new validation for `ArchiveMaxSize` — rejects it when set without `Archive`, when negative, or when it exceeds the 4 GiB ceiling.
- `PackageInstallStepFile` struct: new optional `ArchiveMaxSize int64` field (`archiveMaxSize` in YAML).
- `resolveContent()` (the install steps' shared content-resolution helper): computes an effective `archiveMaxSize` (override or the 512 MiB default) and passes it into `extractArchiveFileWithLimit`; the URL fetch now runs under `context.WithTimeout(..., downloadTimeout)` instead of an unbounded `context.Background()`.
- A handful of pre-existing #561 error-message lines wrapped to stay under 80 chars — no behavior change.

**`pkgmgr/pkgmgr.go`**
- `Install()` and `Upgrade()` each now call the target package's `.validate()` before doing anything else — in `Upgrade()`, before the currently-installed version is deactivated/uninstalled.

**`pkgmgr/archive.go`**
- `maxArchiveEntrySize` changed from `const` to `var` (matches the existing `maxDownloadSize`/`downloadTimeout` pattern) so it's cheaply testable.
- New `maxArchiveSizeCeiling` (4 GiB) bounding how high `archiveMaxSize` can raise the limit.
- New `downloadTimeout` (5 min) backing the URL-download timeout fix.
- `extractArchiveFile`/`extractZipFile` split into thin wrappers over new `...WithLimit` variants (mirroring the existing `extractTarGzFile`/`extractTarGzFileWithLimit` split) so a caller can pass a custom size bound.
- Fixed `extractTarGzFileWithLimit`'s per-entry checks, which were hardcoded to the global constant even though the function already accepted a custom limit parameter — they now consistently use the parameter.
- Rewrote the `readArchiveEntry` and `maxDownloadSize` doc comments, which described a narrower scope than what they'd grown to cover.

**`pkgmgr/archive_test.go`**
- Pre-existing #561 lines over 80 chars wrapped. No logic changes.

**`pkgmgr/package_archive_test.go`**
- New regression test for the `activate()` templated-filename fix.
- New test for the URL download timeout (blocks a test server forever, confirms `install()` returns rather than hanging).
- New `validate()` table cases for `ArchiveMaxSize` (valid, missing `archive`, negative, over ceiling).
- New tests proving the `archiveMaxSize` override reaches the extraction path: one showing a too-small override causes a failure that wouldn't otherwise happen, and a paired test (temporarily lowering `maxArchiveEntrySize` so the test data can stay tiny) showing an override raises the effective limit while the un-overridden default still rejects the same entry.
- Pre-existing #561 lines/comments over 80 chars wrapped.

**`pkgmgr/pkgmgr_install_test.go`** (new file)
- `TestInstallRejectsInvalidPackage`: an available package that fails validation is rejected by `Install()` with no file written and no state mutation.
- `TestUpgradeRejectsInvalidNewPackageVersion`: an invalid upgrade target is rejected *before* the currently-installed version is deactivated/uninstalled.

**`README.md`**
- Documented the new `archiveMaxSize` field in the file-install-step table.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -l` — all clean.
- `go test ./...` — full suite passes, including the new tests above and the existing suite (verified against latest `main`, after rebasing past #578 and #585).
- Manually verified each new test actually catches its regression by temporarily reverting the corresponding fix and confirming the test fails, then restoring the fix and confirming it passes again — done for the `activate()` fix, the `validate()`-wiring fix (both `Install()` and `Upgrade()`), and the `archiveMaxSize` wiring (confirmed via the compiler itself: removing the one call site that consumes `archiveMaxSize` produces a "declared and not used" build error, proving there's no other path that silently ignores the override).
- Did not add line-length cleanup for lines unrelated to #561/this change (traced ambiguous cases via `git log -S` to confirm origin before touching them).

Closes #562 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes five pre-existing bugs in `pkgmgr`'s file install steps: templated filenames now render consistently across activate and uninstall, install and upgrade validate the full plan before mutating anything, URL downloads time out after 5 minutes, and archive extraction supports a per-package size override.

**Bug Fixes**
- `activate()` and `uninstall()` now use the rendered filename; activation previously made dangling symlinks, and upgrade left the old rendered file behind.
- `Install()` and `Upgrade()` validate every package in the resolved plan before acting; previously an invalid entry could tear down the working installed version or leave dependencies partially installed before failing.
- URL-sourced installs now run under a 5-minute `downloadTimeout` instead of an unbounded `context.Background()`.
- New optional `archiveMaxSize` field raises the per-package decompression cap past the 512 MiB default, capped at 4 GiB; for `tar.gz`/`tgz` it bounds total decompressed archive data, while for `zip` it limits just the selected entry.
- The upgrade-rejection test now sets a valid `filePath` so it exercises the missing `content`/`source`/`url` check rather than failing earlier on the path check.
- Removed the now-unused `extractArchiveFile`/`extractZipFile`/`extractTarGzFile` wrappers, routing all extraction through the `...WithLimit` variants directly, and `extractZipFileWithLimit` now rejects a negative `maxSize`.

<sup>Written for commit 37e36b9edea04839aff3fd1df40e9d428eb41d61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up/pull/586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `archiveMaxSize` configuration for controlling decompressed archive-entry sizes, with safe default and maximum limits.
  * Added support for templated filenames when activating binaries.
  * Added download timeouts for URL-based installations.
* **Bug Fixes**
  * Archive errors now identify the affected archive entry.
  * Invalid packages are rejected before installation or upgrade changes occur.
* **Documentation**
  * Documented the new `archiveMaxSize` option and its limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->